### PR TITLE
Fix compilation with FPC 3.2.2, fix missing InitWithEnvironmentVariables

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,17 +44,14 @@ The follow options are supported:
     "-Fi/path/to",
     "-dMY_MACRO"
   ],
-  "options":
-  {
-    "name": "string|number|boolean"
-  },
   "symbolDatabase": "/path/to/symbols.db",
   "maximumCompletions": "number",
   "overloadPolicy": [1,  // duplicate function names appear in the list
                      2,  // after the original definition ignore others
                      3   // add a suffix which denotes the overload count
                      ],
-  "program": "pasls.lpr"
+  "program": "pasls.lpr",
+  ... additional booleans listed below
 }
 ```
 
@@ -77,7 +74,7 @@ The following macro formats are valid:
 
 ### Optional Settings
 
-Boolean values used in *initializationOptions.options*.
+Boolean values used in *initializationOptions*.
 
 ```json
 // procedure completions with parameters are inserted as snippets

--- a/general.pas
+++ b/general.pas
@@ -386,6 +386,15 @@ begin with Params do
     {$ifdef LINUX}
     {$endif}
 
+    { LSP clients (like VS Code: https://github.com/genericptr/pasls-vscode ,
+      Emacs: https://github.com/arjanadriaanse/lsp-pascal ) pass critical parameters
+      as environment variables:
+      PP, FPCDIR, LAZARUSDIR, FPCTARGET, FPCTARGETCPU.
+      And TCodeToolsOptions.InitWithEnvironmentVariables reads them.
+      The CodeTools configuration doesn't work without defining them,
+      you will get error "TFPCUnitToSrcCache.GetConfigCache missing CompilerFilename". }
+    CodeToolsOptions.InitWithEnvironmentVariables;
+
     {$ifdef FreePascalMake}
     { attempt to load settings from FPM config file or search in the
       default workspace if there is there is only one available.

--- a/options.pas
+++ b/options.pas
@@ -153,7 +153,7 @@ type
     // The commands to be executed on the server
     property commands: TStrings read fCommands write fCommands;
   public
-    constructor Create(_commands: TStringArray = []);
+    constructor Create(_commands: TStringArray);
   end;
 
   { TInlayHintOptions }


### PR DESCRIPTION
I was playing with your LSP server for Pascal (in the context of VS Code, Emacs, and making it auto-complete in Castle Game Engine applications). 

I noted 2 problems, this PR fixes them in the simplest possible way (you may know a better way to fix them :) ):

1. Compilation fails with FPC 3.2.2, FPC is confused by `constructor Create(_commands: TStringArray = []);`, thinking `[]` is an empty set.

2. The critical parameters passed through environment (PP, FPCDIR, LAZARUSDIR, FPCTARGET, FPCTARGETCPU) are not passed to the CodeTools, it seems. I was getting `TFPCUnitToSrcCache.GetConfigCache missing CompilerFilename` error when trying to use the LSP server from both VS Code and Emacs, and the log showed that CodeTools just doesn't know the information about processor, FPC path etc.

    I fixed this just by adding `CodeToolsOptions.InitWithEnvironmentVariables`, which seems to be the intention here (the environment variables defined by VS Code and Emacs clients match exactly what the `CodeToolsOptions.InitWithEnvironmentVariables` expects to get).

P.S. I collected my experience with using LSP for Pascal in Emacs on https://github.com/michaliskambi/elisp/tree/master/lsp .