### PR TITLE
compile fix

### DIFF
--- a/lsp.pas
+++ b/lsp.pas
@@ -32,6 +32,9 @@ uses
   basic, memUtils;
 
 type
+  TObjectArray = array of TObject;
+  PObjectArray = ^TObjectArray;
+  PObject = ^TObject;
 
   { TLSPStreamer }
 
@@ -466,10 +469,6 @@ end;
 { TLSPRequest }
 
 function TLSPRequest.DoExecute(const Params: TJSONData; AContext: TJSONRPCCallContext): TJSONData;
-type
-  TObjectArray = array of TObject;
-  PObjectArray = ^TObjectArray;
-  PObject = ^TObject;
 var
   Input: T;
   Output: U;

--- a/options.pas
+++ b/options.pas
@@ -153,7 +153,7 @@ type
     // The commands to be executed on the server
     property commands: TStrings read fCommands write fCommands;
   public
-    constructor Create(_commands: TStringArray = []);
+    constructor Create(_commands: TStringArray);
   end;
 
   { TInlayHintOptions }


### PR DESCRIPTION
I checked out/git pulled the repository and compiled:
Tested this on ubuntu x64 with lazbuild and under win11 x86 with lazarus IDE:

options.pas: didn't compile since TStringArray can't be initialized with default.
lsp.pas: forward declaration in procedure seems to lead to weird exception after first pull/checkout of the source code?

Also see messages.txt for lazbuild log.
[messages.txt](https://github.com/genericptr/pascal-language-server/files/10914684/messages.txt)
