### PR TITLE
Proxy implementation

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,5 +153,42 @@ Requires Free Pascal Compiler version 3.2.0 and Lazarus version 2.0.8,
 open the project file in Lazarus or use the commandline:
 
 ```sh
-lazbuild pasls.lpi
+lazbuild src/standard/pasls.lpi
 ```
+
+## Debugging the LSP server
+
+### The problem
+
+VS Code and other editors that use the LSP server start the LSP server and
+send messages in JSON-RPC style to standard input, and read replies through
+standard output. This makes the LSP server process hard to debug.
+
+### The solution
+To solve this, 2 extra projects have been added:
+
+- **paslssock**:  a LSP server that reads messages from a TCP/IP or Unix
+  socket and sends replies back through the socket.
+
+- **paslsproxy**:  a LSP server that acts as a proxy: it reads messages from
+  standard input, sends them to a TCP/IP or Unix socket. It reads the replies
+  from the socket and writes them to standard output.
+
+Both programs have a -h or --help commandline option which will display all
+configuration options.
+
+### Usage
+
+1. Configure the socket process and proxy process. Both can be configured
+   through a command-line option or a configuration file.
+
+   By default the server listens on port 9898 and the proxy connects through
+   this port.
+
+   For both processes you can specify a log file which will log all communication to that logfile.
+
+2. Start the socket server process (in the IDE or debugger of your choice).
+
+3. Configure VS Code to use the proxy process instead of the standard pasls executable.
+
+4. Happy debugging !

--- a/src/pascallanguageserver.lpg
+++ b/src/pascallanguageserver.lpg
@@ -9,6 +9,16 @@
           <Mode Name="Release"/>
         </BuildModes>
       </Target>
+      <Target FileName="proxy/paslsproxy.lpi">
+        <BuildModes>
+          <Mode Name="Default"/>
+        </BuildModes>
+      </Target>
+      <Target FileName="socketserver/paslssock.lpi">
+        <BuildModes>
+          <Mode Name="Default"/>
+        </BuildModes>
+      </Target>
     </Targets>
   </ProjectGroup>
 </CONFIG>

--- a/src/protocol/LSP.AllCommands.pas
+++ b/src/protocol/LSP.AllCommands.pas
@@ -1,3 +1,22 @@
+// Pascal Language Server - Include all command units in a single place, so all commands are available by using this unit.
+// Copyright 2023 Michael Van Canneyt
+
+// This file is part of Pascal Language Server.
+
+// Pascal Language Server is free software: you can redistribute it
+// and/or modify it under the terms of the GNU General Public License
+// as published by the Free Software Foundation, either version 3 of
+// the License, or (at your option) any later version.
+
+// Pascal Language Server is distributed in the hope that it will be
+// useful, but WITHOUT ANY WARRANTY; without even the implied warranty
+// of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with Pascal Language Server.  If not, see
+// <https://www.gnu.org/licenses/>.
+
 unit LSP.AllCommands;
 
 {$mode objfpc}{$H+}

--- a/src/protocol/LSP.AllCommands.pas
+++ b/src/protocol/LSP.AllCommands.pas
@@ -1,0 +1,32 @@
+unit LSP.AllCommands;
+
+{$mode objfpc}{$H+}
+
+interface
+
+uses
+  LSP.GotoDeclaration,
+  LSP.GotoDefinition,
+  LSP.Completion,
+  LSP.Capabilities,
+  LSP.GotoImplementation,
+  LSP.Hover,
+  LSP.SignatureHelp,
+  LSP.References,
+  LSP.CodeAction,
+  LSP.DocumentHighlight,
+  LSP.DocumentSymbol,
+  LSP.Workspace,
+  LSP.Window,
+  LSP.ExecuteCommand,
+  LSP.InlayHint,
+  LSP.Diagnostics,
+  LSP.General,
+  LSP.Options,
+  LSP.Synchronization,
+  LSP.WorkDoneProgress;
+
+implementation
+
+end.
+

--- a/src/protocol/PasLS.SocketDispatcher.pas
+++ b/src/protocol/PasLS.SocketDispatcher.pas
@@ -1,3 +1,22 @@
+// Pascal Language Server
+// Copyright 2023 Michael Van Canneyt
+
+// Socket-based protocol, used between LSP proxy and socket server - based LSP.
+
+// Pascal Language Server is free software: you can redistribute it
+// and/or modify it under the terms of the GNU General Public License
+// as published by the Free Software Foundation, either version 3 of
+// the License, or (at your option) any later version.
+
+// Pascal Language Server is distributed in the hope that it will be
+// useful, but WITHOUT ANY WARRANTY; without even the implied warranty
+// of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with Pascal Language Server.  If not, see
+// <https://www.gnu.org/licenses/>.
+
 unit PasLS.SocketDispatcher;
 
 {$mode ObjFPC}{$H+}

--- a/src/protocol/PasLS.SocketDispatcher.pas
+++ b/src/protocol/PasLS.SocketDispatcher.pas
@@ -1,0 +1,480 @@
+unit PasLS.SocketDispatcher;
+
+{$mode ObjFPC}{$H+}
+
+interface
+
+uses
+  Classes, SysUtils, fpjson, ssockets,
+  LSP.Base;
+
+{
+  The Protocol is simple message exchange:
+  Client sends message of certain type (see below)
+  Server answsers with message, with same ID.
+}
+
+Const
+  LSPProtocolVersion = 1;
+
+Type
+  TLSPProtocolMessageType = (lpmtRequest,lpmtResponse);
+
+
+  TLSPFrame = Packed Record
+    Version : Byte;
+    MsgType : Byte; // Sent as byte
+    ID : cardinal; // In network order;
+    PayloadLen : cardinal; // In network order
+    PayLoad : TBytes;
+  end;
+
+  ELSPSocket = Class(Exception);
+
+  { TSocketDispatcher }
+
+  { TLSPSocketDispatcher }
+
+  TLSPSocketDispatcher = Class(TLSPBaseDispatcher)
+  private
+    FSocket: TSocketStream;
+    FID : Integer;
+    FSocketClosed: Boolean;
+  Protected
+    function NextID : Cardinal;
+    function ReadFrame(Out Msg: TLSPFrame) : Boolean;
+    function SendFrame(const Msg: TLSPFrame) : Boolean;
+    function ReceiveJSON(aType: TLSPProtocolMessageType): TJSONData;
+    function SendJSON(aType: TLSPProtocolMessageType; aJSON : TJSONData) : Boolean;
+    function HandleException(aException: Exception; IsReceive : Boolean): Boolean; virtual;
+  public
+    Constructor Create(aSocket : TSocketStream); virtual;
+    Property Socket : TSocketStream Read FSocket;
+    Property SocketClosed : Boolean Read FSocketClosed;
+  end;
+
+  TLSPClientSocketDispatcher = Class(TLSPSocketDispatcher)
+  Public
+    function ExecuteRequest(aRequest: TJSONData): TJSONData; override;
+  end;
+
+  TLSPSocketContext = class(TLSPContext);
+
+  { TLSPServerSocketConnectionDispatcher }
+
+  TLSPServerSocketConnectionDispatcher = Class(TLSPSocketDispatcher)
+  Private
+    FContext : TLSPSocketContext;
+    FOnDestroy: TNotifyEvent;
+    FTerminated : Boolean;
+  Public
+    function ExecuteRequest(aRequest: TJSONData): TJSONData; override;
+    Constructor Create(aSocket: TSocketStream); override;
+    Destructor Destroy; override;
+    Procedure RunLoop; virtual;
+    Procedure Terminate; virtual;
+    Property Context : TLSPSocketContext Read FContext Write FContext;
+    Property Terminated : Boolean Read FTerminated;
+    Property OnDestroy: TNotifyEvent Read FOnDestroy Write FOnDestroy;
+  end;
+
+  { TLSPServerSocketDispatcher }
+
+  TThreadMode = (tmNone,tmThreadPerConnection);
+  TLSPServerSocketDispatcher = Class
+  Private
+    FSingleConnect: Boolean;
+    FSocket: TSocketServer;
+    FThreadMode: TThreadMode;
+    FConns : TFPList;
+  Protected
+    procedure TerminateConnections; virtual;
+    procedure RemoveConn(Sender: TObject); virtual;
+    procedure AddConnection(aConn : TLSPServerSocketConnectionDispatcher); virtual;
+    procedure HandleConnection(Sender: TObject; Data: TSocketStream); virtual;
+    function CreateDispatcher(Data: TSocketStream): TLSPServerSocketConnectionDispatcher; virtual;
+    Procedure SetServer(aSocket : TSocketServer);
+    Property Connections : TFPList Read FConns;
+  Public
+    Constructor Create; virtual;
+    Destructor Destroy; override;
+    Procedure InitSocket; virtual; abstract;
+    Procedure RunLoop;
+    Procedure Terminate;
+    Property Socket : TSocketServer Read FSocket;
+    Property ThreadMode : TThreadMode Read FThreadMode Write FThreadMode;
+    Property SingleConnect : Boolean Read FSingleConnect Write FSingleConnect;
+  end;
+
+{$IFDEF UNIX}
+  { TLSPServerUnixSocketDispatcher }
+
+  TLSPServerUnixSocketDispatcher = Class (TLSPServerSocketDispatcher)
+  private
+    FPath: String;
+  Public
+    Constructor Create(aPath : String); reintroduce;
+    Procedure InitSocket; override;
+    Property Path : String Read FPath;
+  end;
+{$ENDIF}
+
+  { TLSPServerTCPSocketDispatcher }
+
+  TLSPServerTCPSocketDispatcher = Class (TLSPServerSocketDispatcher)
+  private
+    FPort: Integer;
+  Public
+    Constructor Create(aPort : Word); reintroduce;
+    Procedure InitSocket; override;
+    Property Port : Integer Read FPort;
+  end;
+
+  { TLSPThread }
+
+  TLSPThread = Class(TThread)
+  Private
+    FContext : TLSPServerSocketConnectionDispatcher;
+  Protected
+    Procedure DoTerminate; override;
+  Public
+    Constructor Create(aContext : TLSPServerSocketConnectionDispatcher);
+    Procedure Execute; override;
+
+    Property Context: TLSPServerSocketConnectionDispatcher Read FContext;
+  end;
+
+implementation
+
+uses sockets;
+
+{ TSocketDispatcher }
+
+constructor TLSPSocketDispatcher.Create(aSocket: TSocketStream);
+begin
+  FSocket:=aSocket;
+end;
+
+function TLSPSocketDispatcher.NextID: Cardinal;
+begin
+  Result:=InterlockedIncrement(FID);
+end;
+
+function TLSPSocketDispatcher.SendFrame(const Msg : TLSPFrame) : Boolean;
+
+Var
+  N : Cardinal;
+
+begin
+  Result:=False;
+  N:=0;
+  if Socket.Write(Msg.Version,SizeOf(Byte))=0 then
+    begin
+    FSocketClosed:=True;
+    exit;
+    end;
+  try
+    Socket.WriteBuffer(Msg.MsgType,SizeOf(Byte));
+    N:=htonl(Msg.ID);
+    Socket.WriteBuffer(N,SizeOf(cardinal));
+    N:=htonl(Msg.PayloadLen);
+    Socket.WriteBuffer(N,SizeOf(cardinal));
+    Socket.WriteBuffer(Msg.Payload[0],Msg.PayloadLen);
+  except
+    // Rather crude
+    FSocketClosed:=True;
+  end;
+end;
+
+function TLSPSocketDispatcher.ReadFrame(out Msg: TLSPFrame): Boolean;
+
+Var
+  N : Cardinal;
+
+begin
+  Result:=False;
+  N:=0;
+  Msg:=Default(TLSPFrame);
+  if Socket.Read(Msg.Version,SizeOf(Byte))=0 then
+    begin
+    FSocketClosed:=True;
+    exit;
+    end;
+  Socket.ReadBuffer(Msg.MsgType,SizeOf(Byte));
+  Socket.ReadBuffer(N,SizeOf(cardinal));
+  Msg.ID:=ntohl(N);
+  Socket.ReadBuffer(N,SizeOf(cardinal));
+  Msg.PayloadLen:=ntohl(N);
+  SetLength(Msg.Payload,Msg.PayloadLen);
+  if Msg.PayloadLen>0 then
+    Socket.ReadBuffer(Msg.Payload[0],Msg.PayloadLen);
+  Result:=(Msg.Version=LSPProtocolVersion);
+end;
+
+
+function TLSPSocketDispatcher.SendJSON(aType: TLSPProtocolMessageType;
+  aJSON: TJSONData): Boolean;
+
+Var
+  Msg : TLSPFrame;
+  JS : TJSONStringType; // Tmp var for debugging purposes.
+
+begin
+  Result:=False;
+  try
+    Msg.Version:=LSPProtocolVersion;
+    Msg.MsgType:=Ord(aType);
+    Msg.ID:=NextID;
+    if Assigned(aJSON) then
+      JS:=aJSON.AsJSON
+    else
+      JS:='';
+    Msg.PayLoad:=TEncoding.UTF8.GetAnsiBytes(JS);
+    Msg.PayloadLen:=Length(Msg.PayLoad);
+    SendFrame(Msg);
+    Result:=True;
+  except
+    On E : Exception do
+      HandleException(E,False);
+  end;
+end;
+
+function TLSPSocketDispatcher.ReceiveJSON(aType : TLSPProtocolMessageType) : TJSONData;
+
+Var
+  Msg : TLSPFrame;
+  JSON : TJSONStringType;
+
+begin
+  Result:=nil;
+  try
+    if Not ReadFrame(Msg) then
+      Exit;
+    if (Msg.MsgType<>ord(aType)) then
+      Exit;
+    if (Msg.PayloadLen=0) then
+      Exit;
+    JSON:=TEncoding.UTF8.GetAnsiString(Msg.Payload);
+    Result:=GetJSON(JSON,True);
+  except
+    On E : Exception do
+      HandleException(E,True);
+  end;
+end;
+
+function TLSPSocketDispatcher.HandleException(aException : Exception; IsReceive : Boolean) : Boolean;
+
+Const
+  Stage : Array[Boolean] of string = ('sending','receiving');
+
+begin
+  Writeln('Exception ',aException.ClassName,' during ',Stage[IsReceive],' : ',aException.Message);
+  Result:=True;
+end;
+
+function TLSPClientSocketDispatcher.ExecuteRequest(aRequest: TJSONData): TJSONData;
+
+
+begin
+  Result:=Nil;
+  if SendJSON(lpmtRequest,aRequest) then
+    Result:=ReceiveJSON(lpmtResponse);
+end;
+
+{ TLSPServerSocketConnectionDispatcher }
+
+function TLSPServerSocketConnectionDispatcher.ExecuteRequest(aRequest: TJSONData
+  ): TJSONData;
+begin
+  Result:=FContext.Execute(aRequest);
+end;
+
+constructor TLSPServerSocketConnectionDispatcher.Create(aSocket: TSocketStream);
+begin
+  inherited Create(aSocket);
+  FContext:=TLSPSocketContext.Create(TLSPLocalDispatcher.Create,True);
+end;
+
+destructor TLSPServerSocketConnectionDispatcher.Destroy;
+begin
+  FreeAndNil(FContext);
+  inherited Destroy;
+end;
+
+procedure TLSPServerSocketConnectionDispatcher.RunLoop;
+
+Var
+  Req,Resp : TJSONData;
+
+begin
+  Req:=Nil;
+  Resp:=Nil;
+  try
+    While not Terminated do
+      begin
+      Req:=ReceiveJSON(lpmtRequest);
+      if Assigned(Req) then
+        begin
+        Resp:=FContext.Execute(req);
+        if not SendJSON(lpmtResponse,Resp) then
+          Terminate;
+        end;
+      FreeAndNil(Resp);
+      FreeAndNil(Req);
+      if SocketClosed then
+        Terminate;
+      end;
+  finally
+    Req.Free;
+    Resp.Free;
+  end;
+end;
+
+procedure TLSPServerSocketConnectionDispatcher.Terminate;
+begin
+  FTerminated:=True;
+end;
+
+{ TLSPServerSocketDispatcher }
+
+Function TLSPServerSocketDispatcher.CreateDispatcher(Data: TSocketStream) : TLSPServerSocketConnectionDispatcher;
+
+begin
+  Result:=TLSPServerSocketConnectionDispatcher.Create(Data);
+end;
+
+procedure TLSPServerSocketDispatcher.HandleConnection(Sender: TObject;
+  Data: TSocketStream);
+
+var
+  Conn : TLSPServerSocketConnectionDispatcher;
+
+begin
+  Conn:=CreateDispatcher(Data);
+  try
+    AddConnection(Conn);
+    Case ThreadMode of
+      tmNone:
+        Conn.RunLoop;
+      tmThreadPerConnection :
+        begin
+        TLSPThread.Create(Conn);
+        Conn:=Nil;
+        end;
+    end;
+  finally
+    Conn.Free;
+  end;
+  if FSingleConnect then
+    Terminate;
+end;
+
+procedure TLSPServerSocketDispatcher.SetServer(aSocket: TSocketServer);
+begin
+  FSocket:=aSocket;
+  FSocket.OnConnect:=@HandleConnection;
+end;
+
+constructor TLSPServerSocketDispatcher.Create;
+begin
+  FConns:=TFPList.Create;
+end;
+
+destructor TLSPServerSocketDispatcher.Destroy;
+begin
+  FreeAndNil(FConns);
+  inherited Destroy;
+end;
+
+procedure TLSPServerSocketDispatcher.TerminateConnections;
+
+Var
+  I : Integer;
+
+begin
+  For I:=FConns.Count-1 downto 0 do
+    TLSPServerSocketConnectionDispatcher(FConns[i]).Terminate;
+end;
+
+procedure TLSPServerSocketDispatcher.RemoveConn(Sender: TObject);
+begin
+  FConns.Remove(Sender);
+end;
+
+procedure TLSPServerSocketDispatcher.AddConnection(
+  aConn: TLSPServerSocketConnectionDispatcher);
+begin
+  aConn.OnDestroy:=@RemoveConn;
+  FConns.Add(aConn);
+end;
+
+procedure TLSPServerSocketDispatcher.RunLoop;
+
+begin
+  if not assigned(FSocket) then
+    Raise ELSPSocket.Create('Cannot run loop: Socket not assigned');
+  FSocket.StartAccepting;
+end;
+
+procedure TLSPServerSocketDispatcher.Terminate;
+begin
+  if not assigned(FSocket) then
+    Exit;
+  TerminateConnections;
+  FSocket.StopAccepting(True);
+end;
+
+{$IFDEF UNIX}
+{ TLSPServerUnixSocketDispatcher }
+
+constructor TLSPServerUnixSocketDispatcher.Create(aPath: String);
+begin
+  Inherited Create;
+  FPath:=aPath;
+end;
+
+procedure TLSPServerUnixSocketDispatcher.InitSocket;
+begin
+  SetServer(TUnixServer.Create(FPath))
+end;
+
+{ TLSPServerTCPSocketDispatcher }
+
+constructor TLSPServerTCPSocketDispatcher.Create(aPort: Word);
+begin
+  Inherited Create;
+  FPort:=aPort;
+end;
+
+procedure TLSPServerTCPSocketDispatcher.InitSocket;
+begin
+  SetServer(TInetServer.Create(FPort));
+end;
+{$ENDIF}
+
+{ TLSPThread }
+
+procedure TLSPThread.DoTerminate;
+begin
+  inherited DoTerminate;
+  FContext.Terminate;
+end;
+
+constructor TLSPThread.Create(aContext: TLSPServerSocketConnectionDispatcher);
+begin
+  FContext:=aContext;
+  FreeOnTerminate:=True;
+  Inherited Create(False);
+end;
+
+procedure TLSPThread.Execute;
+begin
+  try
+    FContext.RunLoop;
+  finally
+    FreeAndNil(FContext)
+  end;
+end;
+
+end.
+

--- a/src/protocol/PasLS.TextLoop.pas
+++ b/src/protocol/PasLS.TextLoop.pas
@@ -1,0 +1,156 @@
+unit PasLS.TextLoop;
+
+{$mode ObjFPC}{$H+}
+
+interface
+
+uses
+  Classes, SysUtils, LSP.Base, fpjson;
+
+Procedure SetupTextLoop;
+Procedure RunMessageLoop(var aInput,aOutput,aError : Text; aContext : TLSPContext);
+procedure DebugSendMessage(var aFile : Text; aContext : TLSPContext; const aMethod, aParams: String);
+
+implementation
+
+Procedure SetupTextLoop;
+
+begin
+  TJSONData.CompressedJSON := True;
+  SetTextLineEnding(Input, #13#10);
+  SetTextLineEnding(Output, #13#10);
+end;
+
+
+procedure DebugSendMessage(var aFile : Text; aContext : TLSPContext; const aMethod, aParams: String);
+
+var
+  Content: TJSONStringType;
+  Request: TJSONData;
+  Response: TJSONData;
+
+begin
+  Response:=Nil;
+  Writeln(aFile,'▶️ ', aMethod);
+  Content := '{"jsonrpc": "2.0","id": '+aContext.NextMessageID.ToString+', "method": "'+aMethod+'","params": '+aParams+'}';
+  Request := GetJSON(Content, True);
+  try
+    Response := aContext.Execute(Request);
+    if Assigned(Response) then
+      begin
+      writeln(aFile,'◀️ response: ');
+      writeln(aFile,Response.FormatJSON);
+      Flush(aFile);
+      end;
+  finally
+    Request.Free;
+    Response.Free;
+  end;
+end;
+
+
+
+Function ReadRequest(var aFile : text; aContext : TLSPContext) : TJSONData;
+
+Var
+  Header,Name,Value: String;
+  Content : TJSONStringType;
+  I,ContentLength : Integer;
+  P : PJSONCharType;
+
+begin
+  Result:=Nil;
+  aContext.Log('Reading request');
+  ReadLn(aFile,Header);
+  while Header <> '' do
+    begin
+      aContext.Log('Read header: %s',[Header]);
+      I := Pos(':', Header);
+      Name := Copy(Header, 1, I - 1);
+      Delete(Header, 1, i);
+      Value := Trim(Header);
+      if Name = 'Content-Length' then
+        ContentLength := StrToIntDef(Value,0);
+      ReadLn(aFile,Header);
+    end;
+  Content:='';
+  SetLength(Content,ContentLength);
+  P:=PJSONCharType(Content);
+  for I:=1 to ContentLength do
+    begin
+    Read(aFile,P^);
+    inc(P);
+    end;
+  if Content<>'' then
+    Result:=GetJSON(Content, True);
+end;
+
+Procedure SendResponse(var aFile,aError : text; aContext : TLSPContext; aResponse : TJSONData; aFreeResponse : Boolean = True);
+
+Var
+  Content : TJSONStringType;
+
+begin
+  try
+    if not IsResponseValid(aResponse) then
+      begin
+      aContext.Log('Response not valid: %s',[aResponse.AsJSON]);
+      Writeln(aError, 'invalid response -> ', aResponse.AsJSON);
+      Flush(aError);
+      exit;
+      end;
+    Content := aResponse.AsJSON;
+    WriteLn(aFile,'Content-Type: ', LSPContentType);
+    WriteLn(aFile,'Content-Length: ', Length(Content));
+    WriteLn(aFile);
+    Write(aFile,Content);
+    Flush(aFile);
+    aContext.Log('Wrote response to request');
+  finally
+    if aFreeResponse then
+      aResponse.Free;
+  end;
+end;
+
+Procedure RunMessageLoop(var aInput,aOutput,aError : Text; aContext : TLSPContext);
+
+var
+  Request, Response: TJSONData;
+  VerboseDebugging: boolean = false;
+
+begin
+  Request:=Nil;
+  try
+    while not EOF(aInput) do
+      begin
+      Request:=ReadRequest(aInput,aContext);
+      // log request payload
+      if VerboseDebugging then
+        begin
+          Writeln(aError, Request.FormatJSON);
+          Flush(aError);
+        end;
+      Response := aContext.Execute(Request);
+      if Assigned(Response) then
+        begin
+        // log response payload
+        if VerboseDebugging then
+          begin
+          writeln(aError, Response.asJSON);
+          Flush(aError);
+          end;
+        SendResponse(aOutput,aError,aContext, Response,True);
+        end
+      else
+        aContext.Log('No response to request');
+      FreeAndNil(Request);
+      end;
+  finally
+    Request.Free;
+  end;
+end;
+
+
+
+end.
+

--- a/src/protocol/PasLS.TextLoop.pas
+++ b/src/protocol/PasLS.TextLoop.pas
@@ -1,3 +1,22 @@
+// Pascal Language Server
+// Copyright 2023 Michael Van Canneyt
+
+// LSP Text/File based protocol - in particular, Standard Input/Output/Error files.
+
+// Pascal Language Server is free software: you can redistribute it
+// and/or modify it under the terms of the GNU General Public License
+// as published by the Free Software Foundation, either version 3 of
+// the License, or (at your option) any later version.
+
+// Pascal Language Server is distributed in the hope that it will be
+// useful, but WITHOUT ANY WARRANTY; without even the implied warranty
+// of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with Pascal Language Server.  If not, see
+// <https://www.gnu.org/licenses/>.
+
 unit PasLS.TextLoop;
 
 {$mode ObjFPC}{$H+}

--- a/src/protocol/lspprotocol.lpk
+++ b/src/protocol/lspprotocol.lpk
@@ -126,6 +126,18 @@
         <Filename Value="PasLS.LazConfig.pas"/>
         <UnitName Value="PasLS.LazConfig"/>
       </Item>
+      <Item>
+        <Filename Value="PasLS.TextLoop.pas"/>
+        <UnitName Value="PasLS.TextLoop"/>
+      </Item>
+      <Item>
+        <Filename Value="PasLS.SocketDispatcher.pas"/>
+        <UnitName Value="PasLS.SocketDispatcher"/>
+      </Item>
+      <Item>
+        <Filename Value="LSP.AllCommands.pas"/>
+        <UnitName Value="LSP.AllCommands"/>
+      </Item>
     </Files>
     <RequiredPkgs>
       <Item>

--- a/src/protocol/lspprotocol.pas
+++ b/src/protocol/lspprotocol.pas
@@ -14,7 +14,8 @@ uses
   LSP.Capabilities, LSP.Completion, LSP.General, LSP.Base, LSP.Options, 
   LSP.References, PasLS.Settings, LSP.SignatureHelp, PasLS.Symbols, 
   LSP.Synchronization, LSP.Window, LSP.WorkDoneProgress, LSP.Workspace, 
-  PasLS.CodeUtils, PasLS.Commands, PasLS.LazConfig, LazarusPackageIntf;
+  PasLS.CodeUtils, PasLS.Commands, PasLS.LazConfig, PasLS.TextLoop, 
+  PasLS.SocketDispatcher, LSP.AllCommands, LazarusPackageIntf;
 
 implementation
 

--- a/src/proxy/PasLSProxy.Config.pas
+++ b/src/proxy/PasLSProxy.Config.pas
@@ -1,0 +1,141 @@
+// Pascal Language Server
+// Copyright 2023 Michael Van Canneyt
+
+// Socket-based protocol server - configuration options
+
+// Pascal Language Server is free software: you can redistribute it
+// and/or modify it under the terms of the GNU General Public License
+// as published by the Free Software Foundation, either version 3 of
+// the License, or (at your option) any later version.
+
+// Pascal Language Server is distributed in the hope that it will be
+// useful, but WITHOUT ANY WARRANTY; without even the implied warranty
+// of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with Pascal Language Server.  If not, see
+// <https://www.gnu.org/licenses/>.
+
+unit PasLSProxy.Config;
+
+{$mode ObjFPC}{$H+}
+
+interface
+
+uses
+  Classes, SysUtils, IniFiles;
+
+
+Const
+  DefaultSocketUnix = '';
+  DefaultSocketPort = 9898;
+  DefaultLogFile = '';
+
+Type
+  { TLSPProxyConfig }
+
+  TLSPProxyConfig = Class(TObject)
+  private
+    FLogFile: String;
+    FPort: Word;
+    FSingleConnect: Boolean;
+    FThreaded: Boolean;
+    FUnix: String;
+  Public
+    Constructor Create; virtual;
+    Procedure Reset; virtual;
+    class Function DefaultConfigFile : String;
+    Procedure LoadFromFile(const aFileName : String);
+    Procedure SaveToFile(const aFileName : String);
+    Procedure LoadFromIni(aIni : TCustomIniFile); virtual;
+    Procedure SaveToIni(aIni : TCustomIniFile); virtual;
+  Public
+    Property Port : Word Read FPort Write FPort;
+    Property Unix : String Read FUnix Write FUnix;
+    Property LogFile : String Read FLogFile Write FLogFile;
+  end;
+
+
+implementation
+
+Const
+  SProxy = 'Proxy';
+  KeyPort = 'Port';
+  KeyUnix = 'Unix';
+  KeyLogFile = 'LogFile';
+
+{ TLSPProxyConfig }
+
+constructor TLSPProxyConfig.Create;
+begin
+  Reset;
+end;
+
+procedure TLSPProxyConfig.Reset;
+begin
+  FPort:=DefaultSocketPort;
+  FUnix:=DefaultSocketUnix;
+  LogFile:=DefaultLogFile;
+end;
+
+class function TLSPProxyConfig.DefaultConfigFile: String;
+begin
+{$IFDEF UNIX}
+  Result:='/etc/paslssock.cfg';
+{$ELSE}
+  Result:=ChangeFileExt(ParamStr(0),'.ini');
+{$ENDIF}
+end;
+
+procedure TLSPProxyConfig.LoadFromFile(const aFileName: String);
+
+Var
+  Ini : TCustomIniFile;
+
+begin
+  Ini:=TMemIniFile.Create(aFileName);
+  try
+    LoadFromIni(Ini);
+  finally
+    Ini.Free;
+  end;
+end;
+
+procedure TLSPProxyConfig.SaveToFile(const aFileName: String);
+Var
+  Ini : TCustomIniFile;
+
+begin
+  Ini:=TMemIniFile.Create(aFileName);
+  try
+    SaveToIni(Ini);
+    Ini.UpdateFile;
+  finally
+    Ini.Free;
+  end;
+end;
+
+procedure TLSPProxyConfig.LoadFromIni(aIni: TCustomIniFile);
+begin
+  With aIni do
+    begin
+    FPort:=ReadInteger(SProxy,KeyPort,FPort);
+    FUnix:=ReadString(SProxy,KeyUnix,FUnix);
+    FLogFile:=ReadString(SProxy,KeyLogFile,LogFile);
+    end;
+end;
+
+procedure TLSPProxyConfig.SaveToIni(aIni: TCustomIniFile);
+begin
+  With aIni do
+    begin
+    WriteInteger(SProxy,KeyPort,FPort);
+    WriteString(SProxy,KeyUnix,FUnix);
+    WriteString(SProxy,KeyLogFile,LogFile);
+    end;
+end;
+
+
+end.
+

--- a/src/proxy/paslsproxy.lpi
+++ b/src/proxy/paslsproxy.lpi
@@ -33,10 +33,6 @@
         <Filename Value="paslsproxy.lpr"/>
         <IsPartOfProject Value="True"/>
       </Unit>
-      <Unit>
-        <Filename Value="lspsocketdispatcher.pas"/>
-        <IsPartOfProject Value="True"/>
-      </Unit>
     </Units>
   </ProjectOptions>
   <CompilerOptions>

--- a/src/proxy/paslsproxy.lpi
+++ b/src/proxy/paslsproxy.lpi
@@ -33,6 +33,10 @@
         <Filename Value="paslsproxy.lpr"/>
         <IsPartOfProject Value="True"/>
       </Unit>
+      <Unit>
+        <Filename Value="PasLSProxy.Config.pas"/>
+        <IsPartOfProject Value="True"/>
+      </Unit>
     </Units>
   </ProjectOptions>
   <CompilerOptions>

--- a/src/proxy/paslsproxy.lpi
+++ b/src/proxy/paslsproxy.lpi
@@ -1,0 +1,70 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<CONFIG>
+  <ProjectOptions>
+    <Version Value="12"/>
+    <General>
+      <Flags>
+        <MainUnitHasCreateFormStatements Value="False"/>
+        <MainUnitHasTitleStatement Value="False"/>
+        <MainUnitHasScaledStatement Value="False"/>
+      </Flags>
+      <SessionStorage Value="InProjectDir"/>
+      <Title Value="paslsproxy"/>
+      <UseAppBundle Value="False"/>
+      <ResourceType Value="res"/>
+    </General>
+    <BuildModes>
+      <Item Name="Default" Default="True"/>
+    </BuildModes>
+    <PublishOptions>
+      <Version Value="2"/>
+      <UseFileFilters Value="True"/>
+    </PublishOptions>
+    <RunParams>
+      <FormatVersion Value="2"/>
+    </RunParams>
+    <RequiredPackages>
+      <Item>
+        <PackageName Value="lspprotocol"/>
+      </Item>
+    </RequiredPackages>
+    <Units>
+      <Unit>
+        <Filename Value="paslsproxy.lpr"/>
+        <IsPartOfProject Value="True"/>
+      </Unit>
+      <Unit>
+        <Filename Value="lspsocketdispatcher.pas"/>
+        <IsPartOfProject Value="True"/>
+      </Unit>
+    </Units>
+  </ProjectOptions>
+  <CompilerOptions>
+    <Version Value="11"/>
+    <Target>
+      <Filename Value="paslsproxy"/>
+    </Target>
+    <SearchPaths>
+      <IncludeFiles Value="$(ProjOutDir)"/>
+      <UnitOutputDirectory Value="lib/$(TargetCPU)-$(TargetOS)"/>
+    </SearchPaths>
+    <Linking>
+      <Debugging>
+        <DebugInfoType Value="dsDwarf3"/>
+      </Debugging>
+    </Linking>
+  </CompilerOptions>
+  <Debugging>
+    <Exceptions>
+      <Item>
+        <Name Value="EAbort"/>
+      </Item>
+      <Item>
+        <Name Value="ECodetoolError"/>
+      </Item>
+      <Item>
+        <Name Value="EFOpenError"/>
+      </Item>
+    </Exceptions>
+  </Debugging>
+</CONFIG>

--- a/src/proxy/paslsproxy.lpr
+++ b/src/proxy/paslsproxy.lpr
@@ -1,0 +1,99 @@
+program paslsproxy;
+
+// Pascal Language Server dispatcher
+// Copyright 2023 Michael Van Canneyt
+
+// This file is part of Pascal Language Server.
+
+// Pascal Language Server is free software: you can redistribute it
+// and/or modify it under the terms of the GNU General Public License
+// as published by the Free Software Foundation, either version 3 of
+// the License, or (at your option) any later version.
+
+// Pascal Language Server is distributed in the hope that it will be
+// useful, but WITHOUT ANY WARRANTY; without even the implied warranty
+// of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with Pascal Language Server.  If not, see
+// <https://www.gnu.org/licenses/>.
+
+{$mode objfpc}{$H+}
+
+uses
+  { RTL }
+  SysUtils, Classes, fpjson, jsonparser, jsonscanner,
+
+  { LSP }
+
+  LSP.Base, PasLS.TextLoop, PasLS.SocketDispatcher,
+
+  ssockets,
+
+  { Pasls }
+  memUtils;
+
+
+Function ExecuteCommandLineMessages(aContext : TLSPContext) : Boolean;
+
+var
+  i: integer;
+  method, path : String;
+
+begin
+  Result:=True;
+  if ParamCount=0 then
+    exit;
+  if (ParamCount mod 2)= 1 then
+    begin
+    writeln('Invalid parameter count of '+ParamCount.ToString+' (must be pairs of 2)');
+    Exit(false);
+    end;
+  I:=1;
+  while i <= ParamCount do
+    begin
+    method := ParamStr(i);
+    path := ExpandFileName(ParamStr(i + 1));
+    if not FileExists(path) then
+      begin
+      writeln('Command path "',path,'" can''t be found');
+      exit(false)
+      end;
+    DebugSendMessage(output,aContext, method, GetFileAsString(path));
+    Inc(i, 2);
+  end;
+end;
+
+Function SetupSocket : TSocketStream;
+
+begin
+  // Todo: Add some code to start the socket server, e.g. when the file does not exist.
+  Result:=TInetsocket.Create('127.0.0.1',9898);
+end;
+
+var
+  aContext : TLSPContext;
+  aSocket : TSocketStream;
+
+begin
+  // Show help for the server
+  if ParamStr(1) = '-h' then
+    begin
+    writeln('Pascal Language Server [',{$INCLUDE %DATE%},']');
+    Halt;
+    end;
+  SetupTextLoop;
+  aSocket:=SetupSocket;
+  try
+    aContext:=TLSPContext.Create(TLSPClientSocketDispatcher.Create(aSocket),True);
+    if not ExecuteCommandLineMessages(aContext) then
+      exit;
+    RunMessageLoop(Input,Output,StdErr,aContext);
+   Finally
+     aContext.Free;
+     aSocket.Free;
+     DrainAutoReleasePool;
+   end;
+end.
+

--- a/src/proxy/paslsproxy.lpr
+++ b/src/proxy/paslsproxy.lpr
@@ -1,6 +1,6 @@
 program paslsproxy;
 
-// Pascal Language Server dispatcher
+// Pascal Language Server proxy dispatcher
 // Copyright 2023 Michael Van Canneyt
 
 // This file is part of Pascal Language Server.

--- a/src/proxy/paslsproxy.lpr
+++ b/src/proxy/paslsproxy.lpr
@@ -40,8 +40,8 @@ Type
   TLSPProxyApplication = Class(TCustomApplication)
   Private
     const
-      ShortOptions = 'htp:u:c:';
-      LongOptions : Array of string = ('help','test','port:','unix:','config:');
+      ShortOptions = 'htp:u:c:l:';
+      LongOptions : Array of string = ('help','test','port:','unix:','config:','log:');
   Private
     FConfig : TLSPProxyConfig;
     function ParseOptions(out aParams : TStringDynArray): Boolean;
@@ -110,6 +110,7 @@ begin
   Writeln('Where options is one or more of:');
   Writeln('-h  --help           This help message');
   Writeln('-c  --config=FILE    Read configuration from file FILE. Default is to read from ',TLSPProxyConfig.DefaultConfigFile);
+  Writeln('-l  --log=FILE       Set log file in which to write all log messages');
   Writeln('-p  --port=NNN       Listen on port NNN (default: ',DefaultSocketPort);
   Writeln('-t  --test           Interpret non-option arguments as call/param file pairs and send to server');
   Writeln('-u  --unix=FILE      Listen on unix socket FILE (only on unix-like systems. Default: ',DefaultSocketUnix,')');
@@ -132,6 +133,8 @@ begin
 {$ENDIF}
   if HasOption('p','port') then
     FConfig.Port:=StrToInt(GetOptionValue('p','port'));
+  if HasOption('l','log') then
+    FConfig.LogFile:=GetOptionValue('l','log');
   if HasOption('t','test') then
     aParams:=GetNonOptions(ShortOptions,LongOptions)
   else

--- a/src/socketserver/PasLSSock.Config.pas
+++ b/src/socketserver/PasLSSock.Config.pas
@@ -1,3 +1,22 @@
+// Pascal Language Server
+// Copyright 2023 Michael Van Canneyt
+
+// Socket-based protocol server - configuration options
+
+// Pascal Language Server is free software: you can redistribute it
+// and/or modify it under the terms of the GNU General Public License
+// as published by the Free Software Foundation, either version 3 of
+// the License, or (at your option) any later version.
+
+// Pascal Language Server is distributed in the hope that it will be
+// useful, but WITHOUT ANY WARRANTY; without even the implied warranty
+// of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with Pascal Language Server.  If not, see
+// <https://www.gnu.org/licenses/>.
+
 unit PasLSSock.Config;
 
 {$mode ObjFPC}{$H+}
@@ -12,12 +31,14 @@ Const
   DefaultSocketPort = 9898;
   DefaultSingleConnect = False;
   DefaultThreaded = False;
+  DefaultLogFile = '';
 
 Type
   { TLSPSocketServerConfig }
 
   TLSPSocketServerConfig = Class(TObject)
   private
+    FLogFile: String;
     FPort: Word;
     FSingleConnect: Boolean;
     FThreaded: Boolean;
@@ -35,6 +56,7 @@ Type
     Property Unix : String Read FUnix Write FUnix;
     Property SingleConnect : Boolean Read FSingleConnect Write FSingleConnect;
     Property Threaded : Boolean Read FThreaded Write FThreaded;
+    Property LogFile : String Read FLogFile Write FLogFile;
   end;
 
 
@@ -46,6 +68,7 @@ Const
   KeyUnix = 'Unix';
   KeySingleConnect = 'SingleConnect';
   KeyThreaded = 'Threaded';
+  KeyLogFile = 'LogFile';
 
 { TLSPSocketServerConfig }
 
@@ -60,6 +83,7 @@ begin
   FUnix:=DefaultSocketUnix;
   FSingleConnect:=DefaultSingleConnect;
   FThreaded:=DefaultThreaded;
+  LogFile:=DefaultLogFile;
 end;
 
 class function TLSPSocketServerConfig.DefaultConfigFile: String;
@@ -107,6 +131,7 @@ begin
     FUnix:=ReadString(SServer,KeyUnix,FUnix);
     FSingleConnect:=ReadBool(SServer,KeySingleConnect,SingleConnect);
     FThreaded:=ReadBool(SServer,KeyThreaded,Threaded);
+    FLogFile:=ReadString(SServer,KeyLogFile,LogFile);
     end;
 end;
 
@@ -118,6 +143,7 @@ begin
     WriteString(SServer,KeyUnix,FUnix);
     WriteBool(SServer,KeySingleConnect,SingleConnect);
     WriteBool(SServer,KeyThreaded,Threaded);
+    WriteString(SServer,KeyLogFile,LogFile);
     end;
 end;
 

--- a/src/socketserver/PasLSSock.Config.pas
+++ b/src/socketserver/PasLSSock.Config.pas
@@ -1,0 +1,126 @@
+unit PasLSSock.Config;
+
+{$mode ObjFPC}{$H+}
+
+interface
+
+uses
+  Classes, SysUtils, Inifiles;
+
+Const
+  DefaultSocketUnix = '';
+  DefaultSocketPort = 9898;
+  DefaultSingleConnect = False;
+  DefaultThreaded = False;
+
+Type
+  { TLSPSocketServerConfig }
+
+  TLSPSocketServerConfig = Class(TObject)
+  private
+    FPort: Word;
+    FSingleConnect: Boolean;
+    FThreaded: Boolean;
+    FUnix: String;
+  Public
+    Constructor Create; virtual;
+    Procedure Reset; virtual;
+    class Function DefaultConfigFile : String;
+    Procedure LoadFromFile(const aFileName : String);
+    Procedure SaveToFile(const aFileName : String);
+    Procedure LoadFromIni(aIni : TCustomIniFile); virtual;
+    Procedure SaveToIni(aIni : TCustomIniFile); virtual;
+  Public
+    Property Port : Word Read FPort Write FPort;
+    Property Unix : String Read FUnix Write FUnix;
+    Property SingleConnect : Boolean Read FSingleConnect Write FSingleConnect;
+    Property Threaded : Boolean Read FThreaded Write FThreaded;
+  end;
+
+
+implementation
+
+Const
+  SServer = 'Server';
+  KeyPort = 'Port';
+  KeyUnix = 'Unix';
+  KeySingleConnect = 'SingleConnect';
+  KeyThreaded = 'Threaded';
+
+{ TLSPSocketServerConfig }
+
+constructor TLSPSocketServerConfig.Create;
+begin
+  Reset;
+end;
+
+procedure TLSPSocketServerConfig.Reset;
+begin
+  FPort:=DefaultSocketPort;
+  FUnix:=DefaultSocketUnix;
+  FSingleConnect:=DefaultSingleConnect;
+  FThreaded:=DefaultThreaded;
+end;
+
+class function TLSPSocketServerConfig.DefaultConfigFile: String;
+begin
+{$IFNDEF UNIX}
+  Result:='/etc/paslssock.cfg';
+{$ELSE}
+  Result:=ChangeFileExt(ParamStr(0),'.ini');
+{$ENDIF}
+end;
+
+procedure TLSPSocketServerConfig.LoadFromFile(const aFileName: String);
+
+Var
+  Ini : TCustomIniFile;
+
+begin
+  Ini:=TMemIniFile.Create(aFileName);
+  try
+    LoadFromIni(Ini);
+  finally
+    Ini.Free;
+  end;
+end;
+
+procedure TLSPSocketServerConfig.SaveToFile(const aFileName: String);
+Var
+  Ini : TCustomIniFile;
+
+begin
+  Ini:=TMemIniFile.Create(aFileName);
+  try
+    SaveToIni(Ini);
+    Ini.UpdateFile;
+  finally
+    Ini.Free;
+  end;
+end;
+
+procedure TLSPSocketServerConfig.LoadFromIni(aIni: TCustomIniFile);
+begin
+  With aIni do
+    begin
+    FPort:=ReadInteger(SServer,KeyPort,FPort);
+    FUnix:=ReadString(SServer,KeyUnix,FUnix);
+    FSingleConnect:=ReadBool(SServer,KeySingleConnect,SingleConnect);
+    FThreaded:=ReadBool(SServer,KeyThreaded,Threaded);
+    end;
+end;
+
+procedure TLSPSocketServerConfig.SaveToIni(aIni: TCustomIniFile);
+begin
+  With aIni do
+    begin
+    WriteInteger(SServer,KeyPort,FPort);
+    WriteString(SServer,KeyUnix,FUnix);
+    WriteBool(SServer,KeySingleConnect,SingleConnect);
+    WriteBool(SServer,KeyThreaded,Threaded);
+    end;
+end;
+
+
+end.
+

--- a/src/socketserver/PasLSSock.Config.pas
+++ b/src/socketserver/PasLSSock.Config.pas
@@ -88,7 +88,7 @@ end;
 
 class function TLSPSocketServerConfig.DefaultConfigFile: String;
 begin
-{$IFNDEF UNIX}
+{$IFDEF UNIX}
   Result:='/etc/paslssock.cfg';
 {$ELSE}
   Result:=ChangeFileExt(ParamStr(0),'.ini');

--- a/src/socketserver/paslssock.lpi
+++ b/src/socketserver/paslssock.lpi
@@ -1,0 +1,69 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<CONFIG>
+  <ProjectOptions>
+    <Version Value="12"/>
+    <General>
+      <Flags>
+        <MainUnitHasCreateFormStatements Value="False"/>
+        <MainUnitHasScaledStatement Value="False"/>
+      </Flags>
+      <SessionStorage Value="InProjectDir"/>
+      <Title Value="Pascal LSP socket server application"/>
+      <UseAppBundle Value="False"/>
+      <ResourceType Value="res"/>
+    </General>
+    <BuildModes>
+      <Item Name="Default" Default="True"/>
+    </BuildModes>
+    <PublishOptions>
+      <Version Value="2"/>
+      <UseFileFilters Value="True"/>
+    </PublishOptions>
+    <RunParams>
+      <FormatVersion Value="2"/>
+    </RunParams>
+    <RequiredPackages>
+      <Item>
+        <PackageName Value="lspprotocol"/>
+      </Item>
+    </RequiredPackages>
+    <Units>
+      <Unit>
+        <Filename Value="paslssock.lpr"/>
+        <IsPartOfProject Value="True"/>
+      </Unit>
+      <Unit>
+        <Filename Value="PasLSSock.Config.pas"/>
+        <IsPartOfProject Value="True"/>
+      </Unit>
+    </Units>
+  </ProjectOptions>
+  <CompilerOptions>
+    <Version Value="11"/>
+    <Target>
+      <Filename Value="paslssock"/>
+    </Target>
+    <SearchPaths>
+      <IncludeFiles Value="$(ProjOutDir)"/>
+      <UnitOutputDirectory Value="lib/$(TargetCPU)-$(TargetOS)"/>
+    </SearchPaths>
+    <Linking>
+      <Debugging>
+        <DebugInfoType Value="dsDwarf3"/>
+      </Debugging>
+    </Linking>
+  </CompilerOptions>
+  <Debugging>
+    <Exceptions>
+      <Item>
+        <Name Value="EAbort"/>
+      </Item>
+      <Item>
+        <Name Value="ECodetoolError"/>
+      </Item>
+      <Item>
+        <Name Value="EFOpenError"/>
+      </Item>
+    </Exceptions>
+  </Debugging>
+</CONFIG>

--- a/src/socketserver/paslssock.lpr
+++ b/src/socketserver/paslssock.lpr
@@ -28,7 +28,7 @@ uses
   cthreads,
   {$ENDIF}
   Classes, SysUtils, CustApp, IniFiles, LSP.AllCommands,
-  PasLSSock.Config, PasLS.SocketDispatcher;
+  LSP.Base, PasLSSock.Config, PasLS.SocketDispatcher;
 
 type
 
@@ -94,6 +94,7 @@ begin
     end;
   if not ParseOptions then
     exit;
+  TLSPContext.LogFile:=FConfig.LogFile;
   if FConfig.Port>0 then
     Disp:=TLSPServerTCPSocketDispatcher.Create(FConfig.Port)
   else

--- a/src/socketserver/paslssock.lpr
+++ b/src/socketserver/paslssock.lpr
@@ -1,5 +1,25 @@
 program paslssock;
 
+// Socket-based Pascal Language Server
+// Copyright 2023 Michael Van Canneyt
+
+// This file is part of Pascal Language Server.
+
+// Pascal Language Server is free software: you can redistribute it
+// and/or modify it under the terms of the GNU General Public License
+// as published by the Free Software Foundation, either version 3 of
+// the License, or (at your option) any later version.
+
+// Pascal Language Server is distributed in the hope that it will be
+// useful, but WITHOUT ANY WARRANTY; without even the implied warranty
+// of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with Pascal Language Server.  If not, see
+// <https://www.gnu.org/licenses/>.
+
+
 {$mode objfpc}{$H+}
 {$modeswitch advancedrecords}
 

--- a/src/socketserver/paslssock.lpr
+++ b/src/socketserver/paslssock.lpr
@@ -65,6 +65,8 @@ begin
 {$ENDIF}
   if HasOption('p','port') then
     FConfig.Port:=StrToInt(GetOptionValue('p','port'));
+  if HasOption('l','log') then
+    FConfig.LogFile:=GetOptionValue('l','log');
   if HasOption('t','threaded') then
     FConfig.Threaded:=True;
   if HasOption('s','single-connect') then
@@ -75,8 +77,8 @@ end;
 procedure TPasLSPSocketServerApp.DoRun;
 
 Const
-  ShortOpts = 'hp:u:c:ts';
-  LongOpts : array of string = ('help','port','unix','config','threaded','single-connect');
+  ShortOpts = 'hp:u:c:tsl:';
+  LongOpts : array of string = ('help','port','unix','config','threaded','single-connect','log:');
 
 
 var
@@ -129,6 +131,7 @@ begin
   Writeln('Where options is one or more of:');
   Writeln('-h  --help           This help message');
   Writeln('-c  --config=FILE    Read configuration from file FILE. Default is to read from ',TLSPSocketServerConfig.DefaultConfigFile);
+  Writeln('-l  --log=FILE       Set log file in which to write all log messages');
   Writeln('-p  --port=NNN       Listen on port NNN');
   Writeln('-s  --single-connect Handle one connection and then exit');
   Writeln('-t  --threaded       Use threading for connections.');

--- a/src/socketserver/paslssock.lpr
+++ b/src/socketserver/paslssock.lpr
@@ -1,0 +1,126 @@
+program paslssock;
+
+{$mode objfpc}{$H+}
+{$modeswitch advancedrecords}
+
+uses
+  {$IFDEF UNIX}
+  cthreads,
+  {$ENDIF}
+  Classes, SysUtils, CustApp, IniFiles, LSP.AllCommands,
+  PasLSSock.Config, PasLS.SocketDispatcher;
+
+type
+
+  { TPasLSPSocketServerApp }
+
+  TPasLSPSocketServerApp = class(TCustomApplication)
+  Private
+    FConfig : TLSPSocketServerConfig;
+    function ParseOptions: Boolean;
+  protected
+    procedure DoRun; override;
+  public
+    constructor Create(TheOwner: TComponent); override;
+    destructor Destroy; override;
+    procedure Usage(const aError: String); virtual;
+  end;
+
+
+{ TPasLSPSocketServerApp }
+
+function TPasLSPSocketServerApp.ParseOptions : Boolean;
+
+var
+  FN : String;
+begin
+  Result:=False;
+  FN:=GetOptionValue('c','config');
+  if FN='' then
+    FN:=TLSPSocketServerConfig.DefaultConfigFile;
+  FConfig.LoadFromFile(FN);
+{$IFDEF UNIX}
+  if HasOption('u','unix') then
+    FConfig.Unix:=GetOptionValue('u','unix');
+{$ENDIF}
+  if HasOption('p','port') then
+    FConfig.Port:=StrToInt(GetOptionValue('p','port'));
+  if HasOption('t','threaded') then
+    FConfig.Threaded:=True;
+  if HasOption('s','single-connect') then
+    FConfig.SingleConnect:=True;
+  Result:=True;
+end;
+
+procedure TPasLSPSocketServerApp.DoRun;
+
+Const
+  ShortOpts = 'hp:u:c:ts';
+  LongOpts : array of string = ('help','port','unix','config','threaded','single-connect');
+
+
+var
+  ErrorMsg: String;
+  Disp : TLSPServerSocketDispatcher;
+
+begin
+  Terminate;
+  // quick check parameters
+  ErrorMsg:=CheckOptions(ShortOpts,LongOpts);
+  if (ErrorMsg<>'') or HasOption('h','help') then
+    begin
+    Usage(ErrorMsg);
+    Exit;
+    end;
+  if not ParseOptions then
+    exit;
+  if FConfig.Port>0 then
+    Disp:=TLSPServerTCPSocketDispatcher.Create(FConfig.Port)
+  else
+    Disp:=TLSPServerUnixSocketDispatcher.Create(FConfig.Unix);
+  Try
+    Disp.SingleConnect:=FConfig.SingleConnect;
+    Disp.InitSocket;
+    Disp.RunLoop;
+  finally
+    Disp.Free;
+  end;
+end;
+
+constructor TPasLSPSocketServerApp.Create(TheOwner: TComponent);
+begin
+  inherited Create(TheOwner);
+  StopOnException:=True;
+  FConfig:=TLSPSocketServerConfig.Create;
+end;
+
+destructor TPasLSPSocketServerApp.Destroy;
+begin
+  FConfig.Free;
+  inherited Destroy;
+end;
+
+procedure TPasLSPSocketServerApp.Usage(const aError : String);
+begin
+  if aError<>'' then
+    Writeln('Error : ',aError);
+  Writeln('Usage: ', ExeName, ' [options]');
+  Writeln('Where options is one or more of:');
+  Writeln('-h  --help           This help message');
+  Writeln('-c  --config=FILE    Read configuration from file FILE. Default is to read from ',TLSPSocketServerConfig.DefaultConfigFile);
+  Writeln('-p  --port=NNN       Listen on port NNN');
+  Writeln('-s  --single-connect Handle one connection and then exit');
+  Writeln('-t  --threaded       Use threading for connections.');
+  Writeln('-u  --unix=FILE      Listen on unix socket FILE (only on unix-like systems)');
+  Writeln('Only one of -p or -u may be specified, if none is specified then the default is to listen on port 9898');
+end;
+
+var
+  Application: TPasLSPSocketServerApp;
+begin
+  Application:=TPasLSPSocketServerApp.Create(nil);
+  Application.Title:='Pascal LSP socket server application';
+  Application.Run;
+  Application.Free;
+end.
+

--- a/src/standard/pasls.lpr
+++ b/src/standard/pasls.lpr
@@ -24,156 +24,60 @@ program pasls;
 
 uses
   { RTL }
+
   SysUtils, Classes, FPJson, JSONParser, JSONScanner, MemUtils,
   { Protocol }
-  LSP.Base, LSP.Basic, LSP.GotoDeclaration, LSP.GotoDefinition, LSP.Completion, LSP.Capabilities,
-  LSP.GotoImplementation, LSP.Hover, LSP.SignatureHelp, LSP.References, LSP.CodeAction,
-  LSP.DocumentHighlight, LSP.DocumentSymbol, LSP.Workspace, LSP.Window, LSP.ExecuteCommand,
-  LSP.InlayHint, LSP.Diagnostics, LSP.General, LSP.Options, PasLS.Symbols, LSP.Synchronization, LSP.WorkDoneProgress;
+  LSP.AllCommands,
+  LSP.Base, LSP.Basic, PasLS.TextLoop;
 
-const
-  ContentType = 'application/vscode-jsonrpc; charset=utf-8';
-
-var
-  LastMessageID: LongInt = 0;
-
-procedure ExecuteCommandLineMessages;
-
-  procedure SendMessage(dispatcher: TLSPDispatcher; method, params: String);
-  var
-    Content: String;
-    Request: TJSONData = nil;
-    Response: TJSONData = nil;
-  begin
-    writeln('▶️ ', method);
-    Content := '{"jsonrpc": "2.0","id": '+LastMessageID.ToString+', "method": "'+method+'","params": '+params+'}';
-    Inc(LastMessageID);
-
-    Request := TJSONParser.Create(Content, DefaultOptions).Parse;
-    Response := Dispatcher.Execute(Request);
-    if Assigned(Response) then
-      begin
-        writeln('◀️ response: ');
-        writeln(Response.FormatJSON);
-        Response.Free;
-      end;
-
-    FreeAndNil(Request);
-  end;
+Function ExecuteCommandLineMessages(aContext : TLSPContext) : Boolean;
 
 var
   i: integer;
-  method, path: String;
-  dispatcher: TLSPDispatcher;
-begin
-  i := 1;
-  dispatcher := TLSPDispatcher.Create(nil);
+  method, path : String;
 
+begin
+  Result:=True;
+  if ParamCount=0 then
+    exit;
+  if (ParamCount div 2)= 1 then
+    begin
+    writeln('Invalid parameter count of '+ParamCount.ToString+' (must be pairs of 2)');
+    Exit(false);
+    end;
+  I:=1;
   while i <= ParamCount do
     begin
-      if ParamCount < i + 1 then
-        begin
-          writeln('Invalid parameter count of '+ParamCount.ToString+' (must be pairs of 2)');
-          Halt(1);
-        end;
-
-      method := ParamStr(i + 0);
-      path := ExpandFileName(ParamStr(i + 1));
-      if not FileExists(path) then
-        begin
-          writeln('Command path "'+path+'" can''t be found');
-          Halt(1);
-        end;
-
-      SendMessage(dispatcher, method, GetFileAsString(path));
-      Inc(i, 2);
-    end;
-
-  DrainAutoReleasePool;
-  Halt;
+    method := ParamStr(i);
+    path := ExpandFileName(ParamStr(i + 1));
+    if not FileExists(path) then
+      begin
+      writeln('Command path "',path,'" can''t be found');
+      exit(false)
+      end;
+    DebugSendMessage(output,aContext, method, GetFileAsString(path));
+    Inc(i, 2);
+  end;
 end;
 
 var
-  Dispatcher: TLSPDispatcher;
-  Header, Name, Value, Content: string;
-  I, ContentLength: Integer;
-  Request, Response: TJSONData;
-  VerboseDebugging: boolean = false;
+  aContext : TLSPContext;
+
 begin
   // Show help for the server
   if ParamStr(1) = '-h' then
     begin
-      writeln('Pascal Language Server [',{$INCLUDE %DATE%},']');
-      Halt;
+    writeln('Pascal Language Server [',{$INCLUDE %DATE%},']');
+    Halt;
     end;
-
-  if ParamCount > 0 then
-    ExecuteCommandLineMessages;
-
-  Dispatcher := TLSPDispatcher.Create(nil);
-  TJSONData.CompressedJSON := True;
-  SetTextLineEnding(Input, #13#10);
-  SetTextLineEnding(Output, #13#10);
-  
-  while not EOF do
-    begin
-      ReadLn(Header);
-      while Header <> '' do
-        begin
-          I := Pos(':', Header);
-          Name := Copy(Header, 1, I - 1);
-          Delete(Header, 1, i);
-          Value := Trim(Header);
-          if Name = 'Content-Length' then ContentLength := StrToInt(Value);
-          ReadLn(Header);
-        end;
-
-      Content := '';
-      SetLength(Content, ContentLength);
-      I := 1;
-      while I <= ContentLength do
-        begin
-          Read(Content[I]);
-          Inc(I);
-        end;
-
-      Request := TJSONParser.Create(Content, DefaultOptions).Parse;
-
-      // log request payload
-      if VerboseDebugging then
-        begin
-          writeln(StdErr, Request.FormatJSON);
-          Flush(StdErr);
-        end;
-        
-      Response := Dispatcher.Execute(Request);
-      if Assigned(Response) then
-        begin
-          if not IsResponseValid(Response) then
-            begin
-              Writeln(StdErr, 'invalid response -> ', response.AsJSON);
-              Flush(StdErr);
-              continue;
-            end;
-          Content := Response.AsJSON;
-          WriteLn('Content-Type: ', ContentType);
-          WriteLn('Content-Length: ', Content.Length);
-          WriteLn;
-          Write(Content);
-          Flush(Output);
-          
-          // log response payload
-          if VerboseDebugging then
-            begin
-              writeln(StdErr, Content);
-              Flush(StdErr);
-            end;
-
-          Response.Free;
-        end;
-
-      Request.Free;
-
-      DrainAutoReleasePool;
-    end;
+  SetupTextLoop;
+  aContext:=TLSPContext.Create(TLSPLocalDispatcher.Create(),True);
+  try
+    if not ExecuteCommandLineMessages(aContext) then
+      exit;
+    RunMessageLoop(Input,Output,StdErr,aContext);
+   Finally
+     aContext.Free;
+     DrainAutoReleasePool;
+   end;
 end.


### PR DESCRIPTION
Hello Ryan,

Here my implementation of a proxy for LSP. 

The server supports a unix socket or TCP/IP socket. 
By default a TCP/IP socket is used which listens on port 9898.

Currently, the proxy connects to port 9898 on localhost; so it should work out of the box.
(it does here)

Everything is in place for making the proxy configurable.

I plan at least a config file for the proxy (it's halfway done). 

I think command-line arguments would also be good, but I have yet to find out how to specify them in a config file/the settings in in VS code. 

The code is set up so that it should be easy to support http/websocket protocols in the proxy.

Once I have the config file ready, I will also add a README.md or extend the current one.