### PR TITLE
Fix memleak initialization

### DIFF
--- a/src/protocol/LSP.Capabilities.pas
+++ b/src/protocol/LSP.Capabilities.pas
@@ -291,6 +291,9 @@ end;
 procedure TServerCapabilities.SetInlayHintProvider(AValue: TInlayHintOptions);
 begin
   if fInlayHintProvider=AValue then Exit;
+  // May not have been created during constructor, so we need to create it here.
+  if fInlayHintProvider=Nil then
+    fInlayHintProvider:=TInlayHintOptions.Create;
   fInlayHintProvider.Assign(AValue);
 end;
 
@@ -335,7 +338,7 @@ begin
   fexecuteCommandProvider := TExecuteCommandOptions.Create([
     'pasls.completeCode'
   ]);
-  finlayHintProvider:= TInlayHintOptions.Create;
+  // finlayHintProvider:= TInlayHintOptions.Create;
 
   documentSymbolProvider := Assigned(SymbolManager);
   if Assigned(Settings) then

--- a/src/protocol/PasLS.LazConfig.pas
+++ b/src/protocol/PasLS.LazConfig.pas
@@ -882,4 +882,10 @@ initialization
 
   PkgNameToPath := TFPStringHashTable.Create;
   PkgCache      := TFPObjectHashTable.Create;
+
+Finalization
+  PkgNameToPath.Free;
+  PkgCache.Free;
+  DebugOutput.Free;
+
 end.

--- a/src/protocol/PasLS.SocketDispatcher.pas
+++ b/src/protocol/PasLS.SocketDispatcher.pas
@@ -68,6 +68,7 @@ Type
     function HandleException(aException: Exception; IsReceive : Boolean): Boolean; virtual;
   public
     Constructor Create(aSocket : TSocketStream); virtual;
+    Destructor Destroy; override;
     Property Socket : TSocketStream Read FSocket;
     Property SocketClosed : Boolean Read FSocketClosed;
   end;
@@ -172,6 +173,12 @@ uses sockets;
 constructor TLSPSocketDispatcher.Create(aSocket: TSocketStream);
 begin
   FSocket:=aSocket;
+end;
+
+destructor TLSPSocketDispatcher.Destroy;
+begin
+  FreeAndNil(FSocket);
+  inherited Destroy;
 end;
 
 function TLSPSocketDispatcher.NextID: Cardinal;
@@ -316,6 +323,8 @@ end;
 
 destructor TLSPServerSocketConnectionDispatcher.Destroy;
 begin
+  If Assigned(FOnDestroy) then
+    FOnDestroy(Self);
   FreeAndNil(FContext);
   inherited Destroy;
 end;
@@ -401,6 +410,7 @@ end;
 
 destructor TLSPServerSocketDispatcher.Destroy;
 begin
+  FreeAndNil(FSocket);
   FreeAndNil(FConns);
   inherited Destroy;
 end;

--- a/src/protocol/PasLS.Symbols.pas
+++ b/src/protocol/PasLS.Symbols.pas
@@ -1145,4 +1145,6 @@ begin
   inherited;
 end;
 
+finalization
+  SymbolManager.Free;
 end.

--- a/src/proxy/PasLSProxy.Config.pas
+++ b/src/proxy/PasLSProxy.Config.pas
@@ -39,8 +39,6 @@ Type
   private
     FLogFile: String;
     FPort: Word;
-    FSingleConnect: Boolean;
-    FThreaded: Boolean;
     FUnix: String;
   Public
     Constructor Create; virtual;

--- a/src/proxy/paslsproxy.lpr
+++ b/src/proxy/paslsproxy.lpr
@@ -73,8 +73,8 @@ begin
     writeln('Invalid parameter count of '+ParamCount.ToString+' (must be pairs of 2)');
     Exit(false);
     end;
-  I:=1;
-  while (i<=Len) do
+  I:=0;
+  while (i<Len) do
     begin
     method := aParams[i];
     path := ExpandFileName(aParams[i+1]);


### PR DESCRIPTION
Hello Ryan,

This patch must merged after the previous one.

It fixes a whole bunch of memory leaks: some are specific to the way process is working and will apply to all calls, 
some fixes are specific to the initialize call. 

If you look in LSP.General, you will see how TPersistent descendents must be coded. 
The same principle must now be applied to all TPersistent descendents:
* Override the 'Assign' method. It must copy all properties from the 'aSource' parameters.
* Create properties of type class in the constructor.
* destroy them in the destructor.
* assign them through a setter that calls the .Assign() method.

With this patch, the server runs and the 'Initialize'call is executed without any memory leaks when the binary stops.