### PR TITLE
* Add default configuration for codetools

### DIFF
--- a/README.md
+++ b/README.md
@@ -178,6 +178,42 @@ To solve this, 2 extra projects have been added:
 Both programs have a -h or --help commandline option which will display all
 configuration options.
 
+### Configuration  
+
+#### paslssock
+The paslssock server can read an initialization file with 2 sections, 
+`Server` and `CodeTools`. These can be used to set another port on which to
+listen, and to specify values for the environment variables that are normally sent by the
+client.
+
+```ini
+[Server]
+Port=10090
+
+[CodeTools]
+Compiler=/usr/local/bin/ppcx64-3.2.2
+FPCDir=/home/michael/FPC/build/svn/tag_3_2_2/fpcsrc
+LazarusDir=/home/michael/projects/lazarus
+TargetOS=linux
+TargetCPU=x86_64
+```
+
+The default location for this configuration file is `/etc/paslssock.cfg` on unix, and next to the
+executable on Windows.
+
+#### paslsproxy
+The proxy can also be configured with an  initialization file with 1
+section: `Server`. This can be used to set the port on which the server is
+listening.
+
+```ini
+[Server]
+Port=10090
+```
+
+The default location for this configuration file is `/etc/paslsproxy.cfg` on unix, and next to the
+executable on Windows.
+
 ### Usage
 
 1. Configure the socket process and proxy process. Both can be configured
@@ -195,5 +231,6 @@ configuration options.
    Simply replace the full path to pasls to the full path to paslsproxy:
 
 ![VS Code: specifying paslsproxy](images/vscodedebug.png)
+
 
 4. Happy debugging !

--- a/src/protocol/PasLS.Settings.pas
+++ b/src/protocol/PasLS.Settings.pas
@@ -117,18 +117,48 @@ type
     property version: string read fVersion write fVersion;
   end;
 
+  { TConfigEnvironmentSettings }
+
+  TConfigEnvironmentSettings = class(TPersistent)
+  Private
+    ffpcDir: string;
+    ffpcTarget: string;
+    ffpcTargetCPU: string;
+    flazarusDir: string;
+    fpp: string;
+  Public
+    Constructor Create;
+    Procedure Assign(aSource : TPersistent); override;
+  published
+    property fpcDir : string Read ffpcDir Write ffpcDir;
+    property pp : string read fpp write fpp;
+    property lazarusDir : string read flazarusDir write flazarusDir;
+    property fpcTarget : string read ffpcTarget write ffpcTarget;
+    property fpcTargetCPU : string read ffpcTargetCPU write ffpcTargetCPU;
+  end;
+
 
 Function ServerSettings: TServerSettings;
 Function ClientInfo: TClientInfo;
+Function EnvironmentSettings:TConfigEnvironmentSettings;
 
 implementation
 
 uses
-  SysUtils;
+  SysUtils, lazUTF8;
 
 var
   _ServerSettings: TServerSettings;
   _ClientInfo: TClientInfo;
+  _EnvironmentSettings:TConfigEnvironmentSettings;
+
+Function EnvironmentSettings:TConfigEnvironmentSettings;
+
+begin
+  if _EnvironmentSettings=Nil then
+    _EnvironmentSettings:=TConfigEnvironmentSettings.Create;
+  Result:=_EnvironmentSettings;
+end;
 
 Function ServerSettings: TServerSettings;
 
@@ -263,6 +293,41 @@ begin
     begin
     Name:=Src.name;
     Version:=Src.version;
+    end
+  else
+    inherited Assign(aSource);
+end;
+
+{ TConfigEnvironmentSettings }
+
+constructor TConfigEnvironmentSettings.Create;
+
+  procedure MaybeSet(aEnvVar : String; aVar : String);
+
+  begin
+    if GetEnvironmentVariableUTF8(aEnvVar)<>'' then
+      aVar:=GetEnvironmentVariableUTF8(aEnvVar);
+  end;
+
+begin
+  MaybeSet('PP',fpp);
+  MaybeSet('FPCDIR',ffpcDir);
+  MaybeSet('LAZARUSDIR',fLazarusDir);
+  MaybeSet('FPCTARGET',ffpcTarget);
+  MaybeSet('FPCTARGETCPU',fpcTargetCPU);
+end;
+
+procedure TConfigEnvironmentSettings.Assign(aSource: TPersistent);
+var
+  src : TConfigEnvironmentSettings absolute aSource;
+begin
+  if aSource is TConfigEnvironmentSettings then
+    begin
+      fpcDir:=src.fpcDir;
+      fpcTarget:=src.fpcTarget;
+      fpcTargetCPU:=src.fpcTargetCPU;
+      lazarusDir:=src.lazarusDir;
+      pp:=src.pp;
     end
   else
     inherited Assign(aSource);

--- a/src/socketserver/PasLSSock.Config.pas
+++ b/src/socketserver/PasLSSock.Config.pas
@@ -32,15 +32,25 @@ Const
   DefaultSingleConnect = False;
   DefaultThreaded = False;
   DefaultLogFile = '';
+  DefaultCompiler = 'fpc';
+  DefaultLazarusDir = '';
+  DefaultFPCDir = '';
+  DefaultTargetOS = {$i %FPCTARGETOS%};
+  DefaultTargetCPU = {$i %FPCTARGETCPU%};
 
 Type
   { TLSPSocketServerConfig }
 
   TLSPSocketServerConfig = Class(TObject)
   private
+    FCompiler: string;
+    FFPCDir: string;
+    FLazarusDir: string;
     FLogFile: String;
     FPort: Word;
     FSingleConnect: Boolean;
+    FTargetCPU: string;
+    FTargetOS: string;
     FThreaded: Boolean;
     FUnix: String;
   Public
@@ -57,6 +67,11 @@ Type
     Property SingleConnect : Boolean Read FSingleConnect Write FSingleConnect;
     Property Threaded : Boolean Read FThreaded Write FThreaded;
     Property LogFile : String Read FLogFile Write FLogFile;
+    property Compiler : string read FCompiler write FCompiler;
+    property FPCDir : string Read FFPCDir Write FFPCDir;
+    property LazarusDir : string read FLazarusDir write FLazarusDir;
+    property TargetOS : string read FTargetOS write FTargetOS;
+    property TargetCPU : string read FTargetCPU write FTargetCPU;
   end;
 
 
@@ -69,6 +84,13 @@ Const
   KeySingleConnect = 'SingleConnect';
   KeyThreaded = 'Threaded';
   KeyLogFile = 'LogFile';
+
+  SCodeTools = 'CodeTools';
+  KeyCompiler = 'Compiler';
+  KeyFPCDir = 'FPCDir';
+  KeyLazarusDir = 'LazarusDir';
+  KeyTargetCPU = 'TargetCPU';
+  KeyTargetOS = 'TargetOS';
 
 { TLSPSocketServerConfig }
 
@@ -84,6 +106,11 @@ begin
   FSingleConnect:=DefaultSingleConnect;
   FThreaded:=DefaultThreaded;
   LogFile:=DefaultLogFile;
+  Compiler:=DefaultCompiler;
+  FPCDir:=DefaultFPCDir;
+  LazarusDir:=DefaultLazarusDir;
+  TargetCPU:=DefaultTargetCPU;
+  TargetOS:=DefaultTargetOS;
 end;
 
 class function TLSPSocketServerConfig.DefaultConfigFile: String;
@@ -132,6 +159,11 @@ begin
     FSingleConnect:=ReadBool(SServer,KeySingleConnect,SingleConnect);
     FThreaded:=ReadBool(SServer,KeyThreaded,Threaded);
     FLogFile:=ReadString(SServer,KeyLogFile,LogFile);
+    Compiler:=ReadString(SCodeTools,KeyCompiler,Compiler);
+    FPCDir:=ReadString(SCodetools,KeyFPCDir,FPCDir);
+    LazarusDir:=ReadString(SCodetools,KeyLazarusDir,LazarusDir);
+    TargetCPU:=ReadString(SCodetools,KeyTargetCPU,TargetCPU);
+    TargetOS:=ReadString(SCodetools,KeyTargetOS,TargetOS);
     end;
 end;
 
@@ -144,6 +176,11 @@ begin
     WriteBool(SServer,KeySingleConnect,SingleConnect);
     WriteBool(SServer,KeyThreaded,Threaded);
     WriteString(SServer,KeyLogFile,LogFile);
+    WriteString(SCodeTools,KeyCompiler,Compiler);
+    WriteString(SCodetools,KeyFPCDir,FPCDir);
+    WriteString(SCodetools,KeyLazarusDir,LazarusDir);
+    WriteString(SCodetools,KeyTargetCPU,TargetCPU);
+    WriteString(SCodetools,KeyTargetOS,TargetOS);
     end;
 end;
 

--- a/src/socketserver/paslssock.lpr
+++ b/src/socketserver/paslssock.lpr
@@ -28,7 +28,7 @@ uses
   cthreads,
   {$ENDIF}
   Classes, SysUtils, CustApp, IniFiles, LSP.AllCommands,
-  LSP.Base, PasLSSock.Config, PasLS.SocketDispatcher;
+  LSP.Base, PasLS.Settings, PasLSSock.Config, PasLS.SocketDispatcher;
 
 type
 
@@ -37,6 +37,7 @@ type
   TPasLSPSocketServerApp = class(TCustomApplication)
   Private
     FConfig : TLSPSocketServerConfig;
+    procedure ConfigureLSP;
     function ParseOptions: Boolean;
   protected
     procedure DoRun; override;
@@ -74,6 +75,20 @@ begin
   Result:=True;
 end;
 
+procedure TPasLSPSocketServerApp.ConfigureLSP;
+
+begin
+  TLSPContext.LogFile:=FConfig.LogFile;
+  With EnvironmentSettings do
+    begin
+    pp:=FConfig.Compiler;
+    fpcDir:=FConfig.FPCDir;
+    lazarusDir:=FConfig.LazarusDir;
+    fpcTarget:=FConfig.TargetOS;
+    fpcTargetCPU:=FConfig.TargetCPU;
+    end;
+end;
+
 procedure TPasLSPSocketServerApp.DoRun;
 
 Const
@@ -96,7 +111,7 @@ begin
     end;
   if not ParseOptions then
     exit;
-  TLSPContext.LogFile:=FConfig.LogFile;
+  ConfigureLSP;
   if FConfig.Port>0 then
     Disp:=TLSPServerTCPSocketDispatcher.Create(FConfig.Port)
   else


### PR DESCRIPTION
Ryan,

Part of the configuration of the codetools happens through environment variables.

But the pasls socket server does not receive these environment variables, since it is not started by VS Code 
(or Sublime Text) so it needs some other means to initialize these variables.

This is part 1 of the solution: 
The socket server reads the settings that are specified in the environment variables also from its config file file. Example of a config file:
 ```ini
[CodeTools]
Compiler=/usr/local/bin/ppcx64-3.2.2
FPCDir=/home/michael/FPC/build/svn/tag_3_2_2/fpcsrc
LazarusDir=/home/michael/projects/lazarus
TargetOS=linux
TargetCPU=x86_64
 ```
I will still add this to the README. I also improved the initialization of these variables.

Part 2 of the solution is to let the proxy send the environment which it received from its editor in an RPC call.
(or to add it to initializationOptions)
