### PR TITLE
* Remove interdependency by splitting units

### DIFF
--- a/src/protocol/LSP.Base.pas
+++ b/src/protocol/LSP.Base.pas
@@ -27,57 +27,16 @@ interface
 
 uses
   { RTL }
-  Classes, SysUtils, TypInfo, RTTIUtils, Contnrs, Types,
+  Classes, SysUtils, TypInfo, RTTIUtils,
   { JSON-RPC }
   fpjson, fpjsonrtti, fpjsonrpc,
   { Pasls }
-  LSP.Basic;
+  LSP.BaseTypes, LSP.Streaming, LSP.Messages;
 
 const
   LSPContentType = 'application/vscode-jsonrpc; charset=utf-8';
 
-
-type
-  TObjectArray = Array of TObject;
-
-  { TLSPStreamer }
-
-  TLSPStreamer = class(TJSONStreamer)
-  protected
-    function StreamClassProperty(const AObject: TObject): TJSONData; override;
-    function ObjectToJSON(Const AObject: TObject): TJSONObject;
-    function StreamProperty(Const AObject: TObject; PropertyInfo: PPropInfo): TJSONData;
-  end;
-
-  { TLSPDeStreamer }
-
-  TLSPDeStreamer = class(TJSONDeStreamer)
-  protected
-    procedure DoRestoreProperty(AObject: TObject; PropInfo: PPropInfo;
-                                PropData: TJSONData); override;
-  end;
-
-  { TLSPStreaming }
-
-  generic TLSPStreaming<T> = class
-  type
-    PObject = ^TObject;
-  private
-    class var Streamer: TLSPStreamer;
-    class var DeStreamer: TLSPDeStreamer;
-    class procedure GetObject(Sender: TOBject; AObject: TObject;
-                              Info: PPropInfo; AData: TJSONObject;
-                              DataName: TJSONStringType; var AValue: TObject); static;
-  public
-    class constructor Create;
-    class destructor Done;
-    class function ToObject(const JSON: TJSONData): T; overload;
-    class function ToObject(const JSON: TJSONStringType): T; overload;
-    class function ToJSON(AObject: TObject): TJSONData; overload;
-    class function ToJSON(AArray: array of TObject): TJSONData; overload;
-  end;
-
-
+Type
   { TLSPRequest
     https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#requestMessage
 
@@ -90,12 +49,16 @@ type
     function Process(var Params : T): U; virtual; abstract;
   end;
 
+  TOutGoingID = Class
+    // One ID for all outgoing requests
+  Class Var
+    OutgoingRequestIndex : Integer;
+  end;
+
   { TLSPOutgoingRequest
     A request from the server to the client }
 
-  generic TLSPOutgoingRequest<T: TPersistent> = class
-  private class var
-    OutgoingRequestIndex: Integer;
+  generic TLSPOutgoingRequest<T: TPersistent> = class(TOutGoingID)
   public
     class procedure Execute(Params: T; Method: String);
   end;
@@ -140,34 +103,6 @@ type
     function ExecuteRequest(aRequest : TJSONData): TJSONData; override;
   end;
 
-
-  { LSPException }
-
-  LSPException = class(Exception)
-  public
-    function Code: Integer; virtual; abstract;
-  end;
-
-  EServerNotInitialized = class(LSPException)
-  public
-    function Code: Integer; override;
-  end;
-
-  EUnknownErrorCode = class(LSPException)
-  public
-    function Code: Integer; override;
-  end;
-
-  // Defined by the protocol.
-  ERequestCancelled = class(LSPException)
-  public
-    function Code: Integer; override;
-  end;
-
-  EContentModified = class(LSPException)
-  public
-    function Code: Integer; override;
-  end;
 
   { TLSPContext }
 
@@ -242,292 +177,6 @@ begin
   Result:=FJSONDispatcher.Execute(aRequest);
 end;
 
-{ TLSPStreamer }
-
-function TLSPStreamer.StreamClassProperty(const AObject: TObject): TJSONData;
-var
-  C: TClass;
-  OptionalVariant: TOptionalVariantBase;
-  OptionalObject: TOptionalObjectBase;
-begin
-  if not Assigned(AObject) then
-    begin
-      result := nil;
-      Exit;
-    end;
-  C := AObject.ClassType;
-  if C.InheritsFrom(TOptionalVariantBase) then
-    begin
-      OptionalVariant := TOptionalVariantBase(AObject);
-      if OptionalVariant.HasValue then
-        Result := StreamVariant(OptionalVariant.Value)
-      else
-        Result := nil
-    end
-  else if C.InheritsFrom(TOptionalObjectBase) then
-    begin
-      OptionalObject := TOptionalObjectBase(AObject);
-      if OptionalObject.HasValue then
-        if OptionalObject.Value = nil then
-          Result := TJSONNull.Create
-        else
-          Result := ObjectToJSON(OptionalObject.Value)
-      else
-        Result := nil
-    end
-  else
-    Result := inherited StreamClassProperty(AObject)
-end;
-
-{ NOTE: This is copied from `fpjsonrtti.pas` until the library supports streaming dynamic arrays }
-function TLSPStreamer.ObjectToJSON(Const AObject: TObject): TJSONObject;
-Var
-  PIL : TPropInfoList;
-  PD : TJSONData;
-  I : Integer;
-begin
-  Result:=Nil;
-  If (AObject=Nil) then
-    Exit;
-  Result:=TJSONObject.Create;
-  try
-    If Assigned(BeforeStreamObject) then
-      BeforeStreamObject(Self,AObject,Result);
-    If AObject is TStrings then
-      Result.Add('Strings',StreamTStrings(Tstrings(AObject)))
-    else If AObject is TCollection then
-      Result.Add('Items',StreamCollection(TCollection(AObject)))
-    else If AObject is TObjectList then
-      Result.Add('Objects',StreamObjectList(TObjectList(AObject)))
-    else if (jsoStreamTlist in Options) and (AObject is TList) then
-      Result.Add('Objects', StreamTList(TList(AObject)))
-    else
-      begin
-      PIL:=TPropInfoList.Create(AObject,tkProperties);
-      try
-        For I:=0 to PIL.Count-1 do
-          begin
-          PD:=StreamProperty(AObject,PIL.Items[i]);
-            If (PD<>Nil) then begin
-              if jsoLowerPropertyNames in Options then
-                Result.Add(LowerCase(PIL.Items[I]^.Name),PD)
-              else
-            Result.Add(PIL.Items[I]^.Name,PD);
-          end;
-          end;
-      finally
-        FReeAndNil(Pil);
-      end;
-      // TODO: StreamChildren is private so we can't support it
-      If (jsoStreamChildren in Options) and (AObject is TComponent) then
-        begin
-          //Result.Add(ChildProperty,StreamChildren(TComponent(AObject)));
-          writeln(StdErr, 'jsoStreamChildren not supported');
-          Flush(StdErr);
-          Halt(-1);
-        end;
-      If Assigned(AfterStreamObject) then
-        AfterStreamObject(Self,AObject,Result);
-      end;
-  except
-    FreeAndNil(Result);
-    Raise;
-  end;
-end;
-
-function TLSPStreamer.StreamProperty(Const AObject: TObject; PropertyInfo: PPropInfo): TJSONData;
-type
-  TVariantArray = array of Variant;
-  TObjectArray = array of TObject;
-var
-  PropArray: TJSONArray;
-  ElementType: PTypeInfo;
-  VariantArray: TVariantArray;
-  ObjectArray: TObjectArray;
-  i: integer;
-begin
-  Result := nil;
-
-  if PropertyInfo^.PropType^.Kind = tkDynArray then
-    begin
-      // Class kinds are in ElType2 (not sure why)
-      ElementType := GetTypeData(PropertyInfo^.PropType)^.ElType;
-      if ElementType = nil then
-        ElementType := GetTypeData(PropertyInfo^.PropType)^.ElType2;
-
-      PropArray := TJSONArray.Create;
-
-      case ElementType^.Kind of
-        tkVariant:
-          begin
-            VariantArray := TVariantArray(GetDynArrayProp(AObject, PropertyInfo));
-            for i := 0 to High(VariantArray) do
-              PropArray.Add(StreamVariant(VariantArray[i]));
-            Result := PropArray;
-          end;
-        tkClass:
-          begin
-            ObjectArray := TObjectArray(GetDynArrayProp(AObject, PropertyInfo));
-            for i := 0 to High(ObjectArray) do
-              PropArray.Add(StreamClassProperty(ObjectArray[i]));
-            result := PropArray;
-          end;
-        otherwise
-          raise EUnknownErrorCode.Create('Dynamic array element type "'+Integer(ElementType^.Kind).ToString+'" is not supported for responses.');
-      end;
-    end
-  else
-    Result := inherited StreamProperty(AObject, PropertyInfo);
-end;
-
-{ TLSPDeStreamer }
-
-procedure TLSPDeStreamer.DoRestoreProperty(AObject: TObject; PropInfo: PPropInfo; PropData: TJSONData);
-var
-  C: TClass;
-  Optional: TObject;
-  OptionalVariant: TOptionalVariantBase;
-  OptionalObject: TOptionalObjectBase;
-  ElementType: PTypeInfo;
-  PropArray: TJSONArray;
-  I: Integer;
-var
-  VariantArray: array of variant;
-  ObjectArray: array of TObject;
-begin
-  VariantArray:=[];
-  ObjectArray:=[];
-  if (PropInfo^.PropType^.Kind = tkDynArray) and (PropData is TJSONArray) then
-    begin
-      // Class kinds are in ElType2 (not sure why)
-      ElementType := GetTypeData(PropInfo^.PropType)^.ElType;
-      if ElementType = nil then
-        ElementType := GetTypeData(PropInfo^.PropType)^.ElType2;
-
-      PropArray := TJSONArray(PropData);
-
-      case ElementType^.Kind of
-        tkVariant:
-          begin
-            SetLength(VariantArray, PropArray.Count);
-            for I := 0 to PropArray.Count - 1 do
-              VariantArray[I] := PropArray[I].Value;
-            SetDynArrayProp(AObject, PropInfo, Pointer(VariantArray));
-          end;
-        tkClass:
-          begin
-            C := GetTypeData(ElementType)^.ClassType;
-
-            SetLength(ObjectArray, PropArray.Count);
-            for I := 0 to PropArray.Count - 1 do
-              if PropArray[I] is TJSONObject then
-                begin
-                  ObjectArray[I] := C.Create;
-                  JSONToObject(TJSONObject(PropArray[I]), ObjectArray[I]);
-                end
-              else
-                raise EUnknownErrorCode.Create('Dynamic array element class must be TJSONObject.');
-
-            SetDynArrayProp(AObject, PropInfo, Pointer(ObjectArray));
-          end;
-        otherwise
-          raise EUnknownErrorCode.Create('Dynamic array element type "'+Integer(ElementType^.Kind).ToString+'" is not supported for responses.');
-      end;
-    end
-  else if PropInfo^.PropType^.Kind = tkClass then
-    begin
-      C := GetTypeData(PropInfo^.PropType)^.ClassType;
-      if C.InheritsFrom(TOptionalVariantBase) then
-        begin
-          Optional := C.Create;
-          OptionalVariant := TOptionalVariantBase(Optional);
-          SetObjectProp(AObject, PropInfo, Optional);
-          OptionalVariant.Value := JSONToVariant(PropData);
-        end
-      else if C.InheritsFrom(TOptionalObjectBase) then
-        begin
-          Optional := C.Create;
-          OptionalObject := TOptionalObjectBase(Optional);
-          SetObjectProp(AObject, PropInfo, Optional);
-          if PropData.JSONType = jtNull then
-            OptionalObject.Value := nil
-          else
-            begin
-              OptionalObject.Value := OptionalObject.ValueClass.Create;
-              JSONToObject(PropData as TJSONObject, OptionalObject.Value);
-            end;
-        end
-      else if C.InheritsFrom(TJSONData) then
-        begin
-          // Clone raw JSON data
-          SetObjectProp(AObject, PropInfo, TJSONData(PropData.Clone));
-        end
-      else
-        inherited DoRestoreProperty(AObject, PropInfo, PropData)
-    end
-  else
-    inherited DoRestoreProperty(AObject, PropInfo, PropData)
-end;
-
-{ TLSPStreaming }
-
-class procedure TLSPStreaming.GetObject(Sender: TOBject; AObject: TObject;
-                                        Info: PPropInfo; AData: TJSONObject;
-                                        DataName: TJSONStringType; var AValue: TObject);
-var
-  C: TClass;
-begin
-  C := GetTypeData(Info^.PropType)^.ClassType;
-  if C.InheritsFrom(TPersistent) then AValue := C.Create;
-end;
-
-class constructor TLSPStreaming.Create;
-begin
-  Streamer := TLSPStreamer.Create(nil);
-  Streamer.Options := Streamer.Options +
-    [jsoEnumeratedAsInteger, jsoSetEnumeratedAsInteger, jsoTStringsAsArray];
-
-  DeStreamer := TLSPDeStreamer.Create(nil);
-  DeStreamer.Options := DeStreamer.Options + [jdoIgnorePropertyErrors, jdoIgnoreNulls];
-  DeStreamer.OnGetObject := @GetObject;
-end;
-
-class destructor TLSPStreaming.Done;
-begin
-  Streamer.Free;
-  Destreamer.Free;
-end;
-
-class function TLSPStreaming.ToObject(const JSON: TJSONData): T;
-begin
-  Result := T.Create;
-  DeStreamer.JSONToObject(JSON as TJSONObject, TObject(Result));
-end;
-
-class function TLSPStreaming.ToObject(const JSON: TJSONStringType): T;
-begin
-  Result := T.Create;
-  DeStreamer.JSONToObject(JSON, TObject(Result));
-end;
-
-class function TLSPStreaming.ToJSON(AObject: TObject): TJSONData;
-begin
-  if AObject.InheritsFrom(TCollection) then
-    Result := Streamer.StreamCollection(TCollection(AObject))
-  else
-    Result := Streamer.ObjectToJSON(AObject);
-end;
-
-class function TLSPStreaming.ToJSON(AArray: array of TObject): TJSONData;
-var
-  AObject: TObject;
-  JArray: TJSONArray;
-begin
-  JArray := TJSONArray.Create;
-  for AObject in AArray do
-    JArray.Add(Streamer.ObjectToJSON(AObject));
-  result := JArray;
-end;
 
 
 { TLSPRequest }
@@ -592,6 +241,7 @@ begin
 end;
 
 { TLSPOutgoingRequest }
+
 
 class procedure TLSPOutgoingRequest.Execute(Params: T; Method: String);
 
@@ -665,27 +315,6 @@ begin
   Options := [jdoSearchRegistry, jdoJSONRPC2, jdoNotifications, jdoStrictNotifications];
 end;
 
-{ LSPException }
-
-function EServerNotInitialized.Code: Integer;
-begin
-  result := -32002;
-end;
-
-function EUnknownErrorCode.Code: Integer;
-begin
-  result := -32001;
-end;
-
-function ERequestCancelled.Code: Integer;
-begin
-  result := -32800;
-end;
-
-function EContentModified.Code: Integer;
-begin
-  result := -32801;
-end;
 
 { LSPHandlerManager }
 

--- a/src/protocol/LSP.BaseTypes.pas
+++ b/src/protocol/LSP.BaseTypes.pas
@@ -1,0 +1,269 @@
+unit LSP.BaseTypes;
+
+{$mode objfpc}{$H+}
+
+interface
+
+uses
+  Classes, SysUtils;
+
+Type
+  TAnyArray = array of Variant;
+
+  { TOptional }
+
+  generic TOptional<T> = class
+  private
+    fHasValue: Boolean;
+    fValue: T;
+    function GetValue: T;
+    procedure SetValue(AValue: T);
+  public
+    property HasValue: Boolean read fHasValue;
+    property Value: T read GetValue write SetValue;
+    procedure Clear;
+  end;
+
+  { TOptionalVariantBase }
+
+  TOptionalVariantBase = class(specialize TOptional<Variant>);
+
+  { TOptionalVariant }
+
+  generic TOptionalVariant<T> = class(TOptionalVariantBase)
+  private
+    function GetValue: T;
+    procedure SetValue(AValue: T);
+  public
+    constructor Create; overload;
+    constructor Create(AValue: T); overload;
+    property Value: T read GetValue write SetValue;
+  end;
+
+  { TOptionalObjectBase }
+
+  TOptionalObjectBase = class(specialize TOptional<TObject>)
+  public
+    function ValueClass: TClass; virtual; abstract;
+  end;
+
+  { TOptionalObject }
+
+  generic TOptionalObject<T> = class(TOptionalObjectBase)
+  private
+    function GetValue: T;
+    procedure SetValue(AValue: T);
+  public
+    constructor Create;
+    constructor Create(AValue: T);
+    function ValueClass: TClass; override;
+    property Value: T read GetValue write SetValue;
+  end;
+
+  TOptionalBoolean = specialize TOptionalVariant<Boolean>;
+  TOptionalString = specialize TOptionalVariant<String>;
+  TOptionalInteger = specialize TOptionalVariant<Integer>;
+  TOptionalAny = specialize TOptionalVariant<Variant>; // any type except structures (objects or arrays)
+  TOptionalNumber = TOptionalInteger;
+
+  { TGenericCollection }
+
+  generic TGenericCollection<T> = class(TCollection)
+  private
+    function GetI(Index : Integer): T;
+    procedure SetI(Index : Integer; AValue: T);
+  public
+    constructor Create;
+    Function Add : T; reintroduce;
+    Property Items[Index : Integer] : T Read GetI Write SetI;
+  end;
+
+
+  { LSPException }
+
+  LSPException = class(Exception)
+  public
+    function Code: Integer; virtual; abstract;
+  end;
+
+  EServerNotInitialized = class(LSPException)
+  public
+    function Code: Integer; override;
+  end;
+
+  EUnknownErrorCode = class(LSPException)
+  public
+    function Code: Integer; override;
+  end;
+
+  // Defined by the protocol.
+  ERequestCancelled = class(LSPException)
+  public
+    function Code: Integer; override;
+  end;
+
+  EContentModified = class(LSPException)
+  public
+    function Code: Integer; override;
+  end;
+
+operator :=(right: Boolean): TOptionalAny;
+operator :=(right: Integer): TOptionalAny;
+operator :=(right: String): TOptionalAny;
+
+operator :=(right: Boolean): TOptionalBoolean;
+operator :=(right: Integer): TOptionalInteger;
+operator :=(right: String): TOptionalString;
+
+
+implementation
+
+{ Utilities }
+
+operator :=(right: Boolean): TOptionalAny;
+begin
+  result := TOptionalAny.Create(right);
+end;
+
+operator :=(right: Integer): TOptionalAny;
+begin
+  result := TOptionalAny.Create(right);
+end;
+
+operator :=(right: String): TOptionalAny;
+begin
+  result := TOptionalAny.Create(right);
+end;
+
+operator :=(right: Boolean): TOptionalBoolean;
+begin
+  result := TOptionalBoolean.Create(right);
+end;
+
+operator :=(right: Integer): TOptionalInteger;
+begin
+  result := TOptionalInteger.Create(right);
+end;
+
+operator :=(right: String): TOptionalString;
+begin
+  result := TOptionalString.Create(right);
+end;
+
+
+{ TOptional }
+
+function TOptional.GetValue: T;
+begin
+  if fHasValue then Result := fValue
+  else Exception.Create('no value');
+end;
+
+procedure TOptional.SetValue(AValue: T);
+begin
+  fValue := AValue;
+  fHasValue := True;
+end;
+
+procedure TOptional.Clear;
+begin
+  fHasValue := False;
+end;
+
+{ TOptionalVariant }
+
+function TOptionalVariant.GetValue: T;
+begin
+  Result := T(inherited Value);
+end;
+
+procedure TOptionalVariant.SetValue(AValue: T);
+begin
+  inherited Value := AValue;
+end;
+
+constructor TOptionalVariant.Create;
+begin
+  inherited Create;
+end;
+
+constructor TOptionalVariant.Create(AValue: T);
+begin
+  Create;
+  SetValue(AValue);
+end;
+
+{ TOptionalObject }
+
+function TOptionalObject.GetValue: T;
+begin
+  Result := T(inherited Value);
+end;
+
+procedure TOptionalObject.SetValue(AValue: T);
+begin
+  inherited Value := AValue;
+end;
+
+constructor TOptionalObject.Create;
+begin
+  inherited Create;
+end;
+
+constructor TOptionalObject.Create(AValue: T);
+begin
+  Create;
+  SetValue(AValue);
+end;
+
+function TOptionalObject.ValueClass: TClass;
+begin
+  Result := T;
+end;
+
+{ TGenericCollection }
+
+function TGenericCollection.GetI(Index : Integer): T;
+begin
+  Result:=T(Inherited Items[Index]);
+end;
+
+procedure TGenericCollection.SetI(Index : Integer; AValue: T);
+begin
+  Inherited Items[Index]:=aValue;
+end;
+
+constructor TGenericCollection.Create;
+begin
+  inherited Create(T);
+end;
+
+function TGenericCollection.Add: T;
+begin
+  Result:=T(Inherited add);
+end;
+
+{ LSPException }
+
+function EServerNotInitialized.Code: Integer;
+begin
+  result := -32002;
+end;
+
+function EUnknownErrorCode.Code: Integer;
+begin
+  result := -32001;
+end;
+
+function ERequestCancelled.Code: Integer;
+begin
+  result := -32800;
+end;
+
+function EContentModified.Code: Integer;
+begin
+  result := -32801;
+end;
+
+end.
+

--- a/src/protocol/LSP.CodeAction.pas
+++ b/src/protocol/LSP.CodeAction.pas
@@ -28,7 +28,7 @@ uses
   { RTL }
   Classes,
   { Protocol }
-  LSP.Base, LSP.Basic;
+  LSP.Base, LSP.Basic, LSP.BaseTypes;
 
 type
   

--- a/src/protocol/LSP.Completion.pas
+++ b/src/protocol/LSP.Completion.pas
@@ -28,7 +28,7 @@ interface
 uses
   Classes, DateUtils, URIParser, 
   CodeToolManager, CodeCache, IdentCompletionTool, BasicCodeTools, CodeTree,
-  LSP.Base, LSP.Basic;
+  LSP.Base, LSP.Basic, LSP.BaseTypes;
 
 type
 

--- a/src/protocol/LSP.Diagnostics.pas
+++ b/src/protocol/LSP.Diagnostics.pas
@@ -29,7 +29,7 @@ uses
   { Code Tools }
   CodeToolManager, CodeCache,
   { Protocol }
-  LSP.Base, LSP.Basic, LSP.Window;
+  LSP.Base, LSP.Basic, LSP.Window, LSP.Messages;
 
 type
 

--- a/src/protocol/LSP.DocumentSymbol.pas
+++ b/src/protocol/LSP.DocumentSymbol.pas
@@ -30,7 +30,7 @@ uses
   { Code Tools }
   CodeToolManager, LinkScanner,
   { Protocol }
-  LSP.Base, LSP.Basic;
+  LSP.Base, LSP.Basic, LSP.BaseTypes, LSP.Streaming;
 
 type
   TSymbolKind = (

--- a/src/protocol/LSP.ExecuteCommand.pas
+++ b/src/protocol/LSP.ExecuteCommand.pas
@@ -26,7 +26,7 @@ uses
   { RTL }
   SysUtils, Classes, FPJSON,
   { Protocol }
-  LSP.Base, LSP.Basic, LSP.WorkDoneProgress;
+  LSP.Base, LSP.Basic, LSP.Streaming, LSP.WorkDoneProgress;
 
 type
   { TExecuteCommandParams

--- a/src/protocol/LSP.General.pas
+++ b/src/protocol/LSP.General.pas
@@ -34,7 +34,7 @@ uses
   { Code Tools }
   CodeToolManager, CodeToolsConfig, 
   { Protocol }
-  LSP.Base, LSP.Basic, LSP.Capabilities, LSP.DocumentSymbol,
+  LSP.Base, LSP.Basic, LSP.BaseTypes, LSP.Capabilities, LSP.DocumentSymbol,
   { Utils }
   PasLS.Settings, PasLS.Symbols, PasLS.LazConfig;
 

--- a/src/protocol/LSP.InlayHint.pas
+++ b/src/protocol/LSP.InlayHint.pas
@@ -26,7 +26,7 @@ interface
 uses
   { RTL }
   Classes, SysUtils,
-  LSP.Base, LSP.Basic;
+  LSP.Base, LSP.Basic, LSP.BaseTypes;
 
 type
   

--- a/src/protocol/LSP.Messages.pas
+++ b/src/protocol/LSP.Messages.pas
@@ -1,0 +1,100 @@
+unit LSP.Messages;
+
+{$mode objfpc}{$H+}
+
+interface
+
+uses
+  Classes, SysUtils, LSP.Streaming, fpJSON, LSP.BaseTypes;
+
+Type
+
+  { TAbstractMessage
+    https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#abstractMessage
+
+    A general message as defined by JSON-RPC. The language server
+    protocol always uses “2.0” as the jsonrpc version. }
+
+  TAbstractMessage = class(TPersistent)
+  private
+    function GetJSONRPC: String;
+  published
+    property jsonrpc: String read GetJSONRPC;
+  public
+    procedure Send;
+  end;
+
+  { TRequestMessage
+    https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#requestMessage
+
+    A request message to describe a request between the client and the server.
+    Every processed request must send a response back to the sender of the request. }
+
+  TRequestMessage = class(TAbstractMessage)
+  protected
+    fID: TOptionalAny; // integer | string
+    fMethod: string;
+    fParams: TPersistent;
+  published
+    // The request id.
+    property id: TOptionalAny read fID write fID;
+    // The method to be invoked.
+    property method: string read fMethod write fMethod;
+    // The notification's params.
+    property params: TPersistent read fParams write fParams;
+  end;
+
+  { TNotificationMessage
+    https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#notificationMessage
+
+    A notification message. A processed notification message
+    must not send a response back. They work like events. }
+
+  TNotificationMessage = class(TAbstractMessage)
+  protected
+    fMethod: string;
+    fParams: TPersistent;
+  published
+    // The method to be invoked.
+    property method: string read fMethod write fMethod;
+    // The notification's params.
+    property params: TPersistent read fParams write fParams;
+  end;
+
+const
+  ContentType = 'application/vscode-jsonrpc; charset=utf-8';
+
+
+implementation
+
+{ TAbstractMessage }
+
+function TAbstractMessage.GetJSONRPC: String;
+begin
+  result := '2.0';
+end;
+
+procedure TAbstractMessage.Send;
+var
+  Data: TJSONData;
+  Content: String;
+begin
+  Data := specialize
+  TLSPStreaming<TAbstractMessage>.ToJSON(self);
+  if Data <> nil then
+    begin
+      Content := Data.AsJSON;
+
+      WriteLn('Content-Type: ', ContentType);
+      WriteLn('Content-Length: ', Content.Length);
+      WriteLn;
+      Write(Content);
+      Flush(Output);
+
+      Data.Free;
+    end;
+end;
+
+
+end.
+

--- a/src/protocol/LSP.Options.pas
+++ b/src/protocol/LSP.Options.pas
@@ -28,7 +28,7 @@ uses
   { RTL }
   SysUtils, Classes,
   { Protocol }
-  LSP.Basic;
+  LSP.BaseTypes;
 
 type
 

--- a/src/protocol/LSP.SignatureHelp.pas
+++ b/src/protocol/LSP.SignatureHelp.pas
@@ -29,7 +29,7 @@ uses
   { Code Tools }
   CodeToolManager, CodeCache, IdentCompletionTool,
   { Protocol }
-  LSP.Base, LSP.Basic;
+  LSP.Base, LSP.Basic, LSP.BaseTypes;
 
 type
 

--- a/src/protocol/LSP.Streaming.pas
+++ b/src/protocol/LSP.Streaming.pas
@@ -1,0 +1,344 @@
+unit LSP.Streaming;
+
+{$mode objfpc}{$H+}
+
+interface
+
+uses
+  RTTIUtils, fpjson, fpjsonrtti, typinfo, contnrs,
+  Classes, SysUtils, LSP.BaseTypes ;
+
+type
+  TObjectArray = Array of TObject;
+
+
+
+  { TLSPStreamer }
+
+  TLSPStreamer = class(TJSONStreamer)
+  protected
+    function StreamClassProperty(const AObject: TObject): TJSONData; override;
+    function ObjectToJSON(Const AObject: TObject): TJSONObject;
+    function StreamProperty(Const AObject: TObject; PropertyInfo: PPropInfo): TJSONData;
+  end;
+
+  { TLSPDeStreamer }
+
+  TLSPDeStreamer = class(TJSONDeStreamer)
+  protected
+    procedure DoRestoreProperty(AObject: TObject; PropInfo: PPropInfo;
+                                PropData: TJSONData); override;
+  end;
+
+  { TLSPStreaming }
+
+  generic TLSPStreaming<T> = class
+  type
+    PObject = ^TObject;
+  private
+    class var Streamer: TLSPStreamer;
+    class var DeStreamer: TLSPDeStreamer;
+    class procedure GetObject(Sender: TOBject; AObject: TObject;
+                              Info: PPropInfo; AData: TJSONObject;
+                              DataName: TJSONStringType; var AValue: TObject); static;
+  public
+    class constructor Create;
+    class destructor Done;
+    class function ToObject(const JSON: TJSONData): T; overload;
+    class function ToObject(const JSON: TJSONStringType): T; overload;
+    class function ToJSON(AObject: TObject): TJSONData; overload;
+    class function ToJSON(AArray: array of TObject): TJSONData; overload;
+  end;
+
+implementation
+
+{ TLSPStreamer }
+
+function TLSPStreamer.StreamClassProperty(const AObject: TObject): TJSONData;
+var
+  C: TClass;
+  OptionalVariant: TOptionalVariantBase;
+  OptionalObject: TOptionalObjectBase;
+begin
+  if not Assigned(AObject) then
+    begin
+      result := nil;
+      Exit;
+    end;
+  C := AObject.ClassType;
+  if C.InheritsFrom(TOptionalVariantBase) then
+    begin
+      OptionalVariant := TOptionalVariantBase(AObject);
+      if OptionalVariant.HasValue then
+        Result := StreamVariant(OptionalVariant.Value)
+      else
+        Result := nil
+    end
+  else if C.InheritsFrom(TOptionalObjectBase) then
+    begin
+      OptionalObject := TOptionalObjectBase(AObject);
+      if OptionalObject.HasValue then
+        if OptionalObject.Value = nil then
+          Result := TJSONNull.Create
+        else
+          Result := ObjectToJSON(OptionalObject.Value)
+      else
+        Result := nil
+    end
+  else
+    Result := inherited StreamClassProperty(AObject)
+end;
+
+{ NOTE: This is copied from `fpjsonrtti.pas` until the library supports streaming dynamic arrays }
+function TLSPStreamer.ObjectToJSON(Const AObject: TObject): TJSONObject;
+Var
+  PIL : TPropInfoList;
+  PD : TJSONData;
+  I : Integer;
+begin
+  Result:=Nil;
+  If (AObject=Nil) then
+    Exit;
+  Result:=TJSONObject.Create;
+  try
+    If Assigned(BeforeStreamObject) then
+      BeforeStreamObject(Self,AObject,Result);
+    If AObject is TStrings then
+      Result.Add('Strings',StreamTStrings(Tstrings(AObject)))
+    else If AObject is TCollection then
+      Result.Add('Items',StreamCollection(TCollection(AObject)))
+    else If AObject is TObjectList then
+      Result.Add('Objects',StreamObjectList(TObjectList(AObject)))
+    else if (jsoStreamTlist in Options) and (AObject is TList) then
+      Result.Add('Objects', StreamTList(TList(AObject)))
+    else
+      begin
+      PIL:=TPropInfoList.Create(AObject,tkProperties);
+      try
+        For I:=0 to PIL.Count-1 do
+          begin
+          PD:=StreamProperty(AObject,PIL.Items[i]);
+            If (PD<>Nil) then begin
+              if jsoLowerPropertyNames in Options then
+                Result.Add(LowerCase(PIL.Items[I]^.Name),PD)
+              else
+            Result.Add(PIL.Items[I]^.Name,PD);
+          end;
+          end;
+      finally
+        FReeAndNil(Pil);
+      end;
+      // TODO: StreamChildren is private so we can't support it
+      If (jsoStreamChildren in Options) and (AObject is TComponent) then
+        begin
+          //Result.Add(ChildProperty,StreamChildren(TComponent(AObject)));
+          writeln(StdErr, 'jsoStreamChildren not supported');
+          Flush(StdErr);
+          Halt(-1);
+        end;
+      If Assigned(AfterStreamObject) then
+        AfterStreamObject(Self,AObject,Result);
+      end;
+  except
+    FreeAndNil(Result);
+    Raise;
+  end;
+end;
+
+function TLSPStreamer.StreamProperty(Const AObject: TObject; PropertyInfo: PPropInfo): TJSONData;
+type
+  TVariantArray = array of Variant;
+  TObjectArray = array of TObject;
+var
+  PropArray: TJSONArray;
+  ElementType: PTypeInfo;
+  VariantArray: TVariantArray;
+  ObjectArray: TObjectArray;
+  i: integer;
+begin
+  Result := nil;
+
+  if PropertyInfo^.PropType^.Kind = tkDynArray then
+    begin
+      // Class kinds are in ElType2 (not sure why)
+      ElementType := GetTypeData(PropertyInfo^.PropType)^.ElType;
+      if ElementType = nil then
+        ElementType := GetTypeData(PropertyInfo^.PropType)^.ElType2;
+
+      PropArray := TJSONArray.Create;
+
+      case ElementType^.Kind of
+        tkVariant:
+          begin
+            VariantArray := TVariantArray(GetDynArrayProp(AObject, PropertyInfo));
+            for i := 0 to High(VariantArray) do
+              PropArray.Add(StreamVariant(VariantArray[i]));
+            Result := PropArray;
+          end;
+        tkClass:
+          begin
+            ObjectArray := TObjectArray(GetDynArrayProp(AObject, PropertyInfo));
+            for i := 0 to High(ObjectArray) do
+              PropArray.Add(StreamClassProperty(ObjectArray[i]));
+            result := PropArray;
+          end;
+        otherwise
+          raise EUnknownErrorCode.Create('Dynamic array element type "'+Integer(ElementType^.Kind).ToString+'" is not supported for responses.');
+      end;
+    end
+  else
+    Result := inherited StreamProperty(AObject, PropertyInfo);
+end;
+
+{ TLSPDeStreamer }
+
+procedure TLSPDeStreamer.DoRestoreProperty(AObject: TObject; PropInfo: PPropInfo; PropData: TJSONData);
+var
+  C: TClass;
+  Optional: TObject;
+  OptionalVariant: TOptionalVariantBase;
+  OptionalObject: TOptionalObjectBase;
+  ElementType: PTypeInfo;
+  PropArray: TJSONArray;
+  I: Integer;
+var
+  VariantArray: array of variant;
+  ObjectArray: array of TObject;
+begin
+  VariantArray:=[];
+  ObjectArray:=[];
+  if (PropInfo^.PropType^.Kind = tkDynArray) and (PropData is TJSONArray) then
+    begin
+      // Class kinds are in ElType2 (not sure why)
+      ElementType := GetTypeData(PropInfo^.PropType)^.ElType;
+      if ElementType = nil then
+        ElementType := GetTypeData(PropInfo^.PropType)^.ElType2;
+
+      PropArray := TJSONArray(PropData);
+
+      case ElementType^.Kind of
+        tkVariant:
+          begin
+            SetLength(VariantArray, PropArray.Count);
+            for I := 0 to PropArray.Count - 1 do
+              VariantArray[I] := PropArray[I].Value;
+            SetDynArrayProp(AObject, PropInfo, Pointer(VariantArray));
+          end;
+        tkClass:
+          begin
+            C := GetTypeData(ElementType)^.ClassType;
+
+            SetLength(ObjectArray, PropArray.Count);
+            for I := 0 to PropArray.Count - 1 do
+              if PropArray[I] is TJSONObject then
+                begin
+                  ObjectArray[I] := C.Create;
+                  JSONToObject(TJSONObject(PropArray[I]), ObjectArray[I]);
+                end
+              else
+                raise EUnknownErrorCode.Create('Dynamic array element class must be TJSONObject.');
+
+            SetDynArrayProp(AObject, PropInfo, Pointer(ObjectArray));
+          end;
+        otherwise
+          raise EUnknownErrorCode.Create('Dynamic array element type "'+Integer(ElementType^.Kind).ToString+'" is not supported for responses.');
+      end;
+    end
+  else if PropInfo^.PropType^.Kind = tkClass then
+    begin
+      C := GetTypeData(PropInfo^.PropType)^.ClassType;
+      if C.InheritsFrom(TOptionalVariantBase) then
+        begin
+          Optional := C.Create;
+          OptionalVariant := TOptionalVariantBase(Optional);
+          SetObjectProp(AObject, PropInfo, Optional);
+          OptionalVariant.Value := JSONToVariant(PropData);
+        end
+      else if C.InheritsFrom(TOptionalObjectBase) then
+        begin
+          Optional := C.Create;
+          OptionalObject := TOptionalObjectBase(Optional);
+          SetObjectProp(AObject, PropInfo, Optional);
+          if PropData.JSONType = jtNull then
+            OptionalObject.Value := nil
+          else
+            begin
+              OptionalObject.Value := OptionalObject.ValueClass.Create;
+              JSONToObject(PropData as TJSONObject, OptionalObject.Value);
+            end;
+        end
+      else if C.InheritsFrom(TJSONData) then
+        begin
+          // Clone raw JSON data
+          SetObjectProp(AObject, PropInfo, TJSONData(PropData.Clone));
+        end
+      else
+        inherited DoRestoreProperty(AObject, PropInfo, PropData)
+    end
+  else
+    inherited DoRestoreProperty(AObject, PropInfo, PropData)
+end;
+
+{ TLSPStreaming }
+
+class procedure TLSPStreaming.GetObject(Sender: TOBject; AObject: TObject;
+                                        Info: PPropInfo; AData: TJSONObject;
+                                        DataName: TJSONStringType; var AValue: TObject);
+var
+  C: TClass;
+begin
+  C := GetTypeData(Info^.PropType)^.ClassType;
+  if C.InheritsFrom(TPersistent) then AValue := C.Create;
+end;
+
+class constructor TLSPStreaming.Create;
+begin
+  Streamer := TLSPStreamer.Create(nil);
+  Streamer.Options := Streamer.Options +
+    [jsoEnumeratedAsInteger, jsoSetEnumeratedAsInteger, jsoTStringsAsArray];
+
+  DeStreamer := TLSPDeStreamer.Create(nil);
+  DeStreamer.Options := DeStreamer.Options + [jdoIgnorePropertyErrors, jdoIgnoreNulls];
+  DeStreamer.OnGetObject := @GetObject;
+end;
+
+class destructor TLSPStreaming.Done;
+begin
+  Streamer.Free;
+  Destreamer.Free;
+end;
+
+class function TLSPStreaming.ToObject(const JSON: TJSONData): T;
+begin
+  Result := T.Create;
+  DeStreamer.JSONToObject(JSON as TJSONObject, TObject(Result));
+end;
+
+class function TLSPStreaming.ToObject(const JSON: TJSONStringType): T;
+begin
+  Result := T.Create;
+  DeStreamer.JSONToObject(JSON, TObject(Result));
+end;
+
+class function TLSPStreaming.ToJSON(AObject: TObject): TJSONData;
+begin
+  if AObject.InheritsFrom(TCollection) then
+    Result := Streamer.StreamCollection(TCollection(AObject))
+  else
+    Result := Streamer.ObjectToJSON(AObject);
+end;
+
+class function TLSPStreaming.ToJSON(AArray: array of TObject): TJSONData;
+var
+  AObject: TObject;
+  JArray: TJSONArray;
+begin
+  JArray := TJSONArray.Create;
+  for AObject in AArray do
+    JArray.Add(Streamer.ObjectToJSON(AObject));
+  result := JArray;
+end;
+
+
+end.
+

--- a/src/protocol/LSP.Window.pas
+++ b/src/protocol/LSP.Window.pas
@@ -27,9 +27,9 @@ uses
   { RTL }
   Classes, 
   { Code Tools }
-  CodeToolManager, CodeCache,
+  CodeToolManager,
   { Protocol }
-  LSP.Base, LSP.Basic;
+  LSP.Base, LSP.BaseTypes, LSP.Messages;
 
 type
   

--- a/src/protocol/LSP.WorkDoneProgress.pas
+++ b/src/protocol/LSP.WorkDoneProgress.pas
@@ -25,9 +25,7 @@ unit LSP.WorkDoneProgress;
 interface
 uses
   { RTL }
-  Classes,
-  { Protocol }
-  LSP.Basic;
+  Classes;
 
 type
   TProgressToken = String; { integer | string }

--- a/src/protocol/LSP.Workspace.pas
+++ b/src/protocol/LSP.Workspace.pas
@@ -27,8 +27,8 @@ uses
   { RTL }
   Classes, fpjson, fpjsonrpc,
   { Protocol }
-  LSP.Base, LSP.Basic, LSP.General, LSP.DocumentSymbol, 
-  PasLS.Settings, PasLS.Symbols;
+  LSP.Base, LSP.Basic, LSP.BaseTypes, LSP.General, LSP.DocumentSymbol,
+  PasLS.Settings, PasLS.Symbols, LSP.Streaming;
 
 type
   

--- a/src/protocol/PasLS.Symbols.pas
+++ b/src/protocol/PasLS.Symbols.pas
@@ -29,9 +29,9 @@ uses
   { Code Tools }
   CodeToolManager, CodeCache, CodeTree, LinkScanner,
   { Protocols }
-  LSP.Base, LSP.Basic, LSP.DocumentSymbol,
+  LSP.Base, LSP.Basic, LSP.BaseTypes, LSP.DocumentSymbol,
   { Other }
-  PasLS.CodeUtils;
+  PasLS.CodeUtils, LSP.Streaming;
 
 type
 

--- a/src/protocol/lspprotocol.lpk
+++ b/src/protocol/lspprotocol.lpk
@@ -139,6 +139,18 @@
         <Filename Value="LSP.AllCommands.pas"/>
         <UnitName Value="LSP.AllCommands"/>
       </Item>
+      <Item>
+        <Filename Value="LSP.Streaming.pas"/>
+        <UnitName Value="LSP.Streaming"/>
+      </Item>
+      <Item>
+        <Filename Value="LSP.BaseTypes.pas"/>
+        <UnitName Value="LSP.BaseTypes"/>
+      </Item>
+      <Item>
+        <Filename Value="LSP.Messages.pas"/>
+        <UnitName Value="LSP.Messages"/>
+      </Item>
     </Files>
     <RequiredPkgs>
       <Item>

--- a/src/protocol/lspprotocol.pas
+++ b/src/protocol/lspprotocol.pas
@@ -15,7 +15,8 @@ uses
   LSP.References, PasLS.Settings, LSP.SignatureHelp, PasLS.Symbols, 
   LSP.Synchronization, LSP.Window, LSP.WorkDoneProgress, LSP.Workspace, 
   PasLS.CodeUtils, PasLS.Commands, PasLS.LazConfig, PasLS.TextLoop, 
-  PasLS.SocketDispatcher, LSP.AllCommands, LazarusPackageIntf;
+  PasLS.SocketDispatcher, LSP.AllCommands, LSP.Streaming, LSP.BaseTypes, 
+  LSP.Messages, LazarusPackageIntf;
 
 implementation
 


### PR DESCRIPTION
Ryan,

Here the patch to remove the inter-dependency of LSP.Base and LSP.Basic.
The responsabilities are also more cleanly separated in the newly added units.
After this patch, you can simply compile the language server instead of having to build.



