### PR TITLE
Transport layer

### DIFF
--- a/src/protocol/LSP.BaseTypes.pas
+++ b/src/protocol/LSP.BaseTypes.pas
@@ -78,6 +78,15 @@ Type
     Property Items[Index : Integer] : T Read GetI Write SetI;
   end;
 
+  { TLSPStreamable }
+
+  TLSPStreamable = class(TPersistent)
+  Public
+    // We need a virtual constructor
+    Constructor Create; virtual;
+  end;
+  TLSPStreamableClass = Class of TLSPStreamable;
+
 
   { LSPException }
 
@@ -241,6 +250,13 @@ end;
 function TGenericCollection.Add: T;
 begin
   Result:=T(Inherited add);
+end;
+
+{ TLSPStreamable }
+
+constructor TLSPStreamable.Create;
+begin
+  Inherited Create;
 end;
 
 { LSPException }

--- a/src/protocol/LSP.Basic.pas
+++ b/src/protocol/LSP.Basic.pas
@@ -38,11 +38,12 @@ type
 
   { TPosition }
 
-  TPosition = class(TPersistent)
+  TPosition = class(TLSPStreamable)
   private
     fLine: Integer;
     fCharacter: Integer;
   public
+    constructor Create; override;
     constructor Create(l, c: integer); overload;
     procedure Assign(Source : TPersistent); override;
   published
@@ -59,7 +60,7 @@ type
 
   { TRange }
 
-  TRange = class(TPersistent)
+  TRange = class(TLSPStreamable)
   private
     fStart: TPosition;
     fEnd: TPosition;
@@ -71,9 +72,12 @@ type
     // The range's end position.
     property &end: TPosition read fEnd write SetEnd;
   public
+    Constructor Create; override;
     constructor Create(line, column: integer); overload;
     constructor Create(line, column, len: integer); overload;
     constructor Create(startLine, startColumn: integer; endLine, endColumn: integer); overload;
+    Procedure  SetRange(line, column: integer; len: integer = 0); overload;
+    Procedure  SetRange(startLine, startColumn: integer; endLine, endColumn: integer); overload;
     Destructor destroy; override;
 
     function ToString: String; override;
@@ -81,13 +85,13 @@ type
 
   { TLocation }
 
-  TLocation = class(TPersistent)
+  TLocation = class(TLSPStreamable)
   private
     fUri: TDocumentUri;
     fRange: TRange;
     procedure SetRange(AValue: TRange);
   public
-    constructor Create; overload;
+    constructor Create; override;
     constructor Create(Path: String; Line, Column, Span: Integer); overload;
     procedure Assign(Source : TPersistent); override;
   published
@@ -107,7 +111,7 @@ type
   Public
     Constructor Create(ACollection: TCollection); override;
     destructor destroy; override;
-    Procedure Assign(source : TPersistent); override;
+    Procedure Assign(Source : TPersistent); override;
   published
     property uri: TDocumentUri read fUri write fUri;
     property range: TRange read fRange write SetRange;
@@ -117,7 +121,7 @@ type
 
   { TLocationLink }
 
-  TLocationLink = class(TPersistent)
+  TLocationLink = class(TLSPStreamable)
   private
     fOriginSelectionRange: TRange;
     fTargetUri: TDocumentUri;
@@ -127,7 +131,7 @@ type
     procedure SetTargetRange(AValue: TRange);
     procedure SetTargetSelectionRange(AValue: TRange);
   public
-    Constructor Create;
+    Constructor Create; override;
     Destructor Destroy; override;
     Procedure Assign(aSource : TPersistent); override;
   published
@@ -153,7 +157,7 @@ type
 
   { TTextDocumentIdentifier }
 
-  TTextDocumentIdentifier = class(TPersistent)
+  TTextDocumentIdentifier = class(TLSPStreamable)
   private
     fUri: TDocumentUri;
   Public
@@ -173,6 +177,7 @@ type
     fVersion: TOptionalInteger;
   public
     Procedure Assign(aSource : TPersistent); override;
+    Destructor Destroy; override;
   published
     // The version number of this document. If a versioned text
     // document identifier is sent from the server to the client and
@@ -232,7 +237,7 @@ type
 
   { TTextDocumentItem }
 
-  TTextDocumentItem = class(TPersistent)
+  TTextDocumentItem = class(TLSPStreamable)
   private
     fUri: TDocumentUri;
     fLanguageId: string;
@@ -254,14 +259,14 @@ type
 
   { TTextDocumentPositionParams }
 
-  TTextDocumentPositionParams = class(TPersistent)
+  TTextDocumentPositionParams = class(TLSPStreamable)
   private
     fTextDocument: TTextDocumentIdentifier;
     fPosition: TPosition;
     procedure SetPosition(AValue: TPosition);
     procedure SetTextDocument(AValue: TTextDocumentIdentifier);
   Public
-    Constructor Create;
+    Constructor Create; override;
     Destructor Destroy; override;
     procedure Assign(Source : TPersistent); override;
   published
@@ -297,17 +302,21 @@ type
     *Please Note* that clients might sanitize the return markdown. A client could decide to
     remove HTML from the markdown to avoid script execution. }
 
-  TMarkupContent = class(TPersistent)
+  TMarkupContent = class(TLSPStreamable)
   private
     fKind: string;
     fValue: string;
+    function GetPlainText: Boolean;
+    procedure SetPlainText(AValue: Boolean);
   published
     // The type of the Markup
     property kind: string read FKind write FKind;
     // The content itself
     property value: string read fValue write fValue;
   public
-    constructor Create(content: string; plainText: boolean = true);
+    constructor create; override;
+    constructor Create(content: string; _plainText: boolean = true);
+    Property PlainText : Boolean Read GetPlainText Write SetPlainText;
     procedure Assign(Source : TPersistent) ; override;
   end;
 
@@ -346,7 +355,7 @@ type
   Public
     Constructor Create(ACollection: TCollection); override;
     destructor destroy; override;
-    Procedure Assign(Source: TPersistent); override;
+    Procedure Assign(Source : TPersistent); override;
   published
     // The location of this related diagnostic information.
     property location: TLocation read fLocation write SetLocation;
@@ -369,7 +378,7 @@ type
   Public
     Constructor Create(ACollection: TCollection); override;
     destructor destroy; override;
-    Procedure Assign(Source: TPersistent); override;
+    Procedure Assign(Source : TPersistent); override;
   published
     // The range at which the message applies.
     property range: TRange read fRange write SetRange;
@@ -408,16 +417,16 @@ type
     Alternatively the tool extension code could handle the command. 
     The protocol currently doesn’t specify a set of well-known commands. }
 
-  TCommand = class(TPersistent)
+  TCommand = class(TLSPStreamable)
   private
     fTitle: string;
     fCommand: string;
     fArguments: TStrings;
     procedure SetArguments(AValue: TStrings);
   public
-    Constructor Create;
+    Constructor Create; override;
     destructor destroy; override;
-    Procedure Assign(Source: TPersistent); override;
+    Procedure Assign(Source : TPersistent); override;
   published
     // Title of the command, like `save`.
     property title: string read fTitle write fTitle;
@@ -439,7 +448,7 @@ type
     If the client can handle versioned document edits and if documentChanges are present, 
     the latter are preferred over changes. }
   
-  TWorkspaceEdit = class(TPersistent)
+  TWorkspaceEdit = class(TLSPStreamable)
   private
     fChanges: TCollection;
     fDocumentChanges: TTextDocumentEdits;
@@ -519,7 +528,7 @@ begin
   inherited;
 end;
 
-procedure TTextEdit.Assign(aSource: TPersistent);
+procedure TTextEdit.Assign(aSource : TPersistent);
 
 var
   Src : TTextEdit absolute aSource;
@@ -564,7 +573,7 @@ begin
   inherited;
 end;
 
-procedure TTextDocumentEdit.Assign(Source: TPersistent);
+procedure TTextDocumentEdit.Assign(Source : TPersistent);
 
 var
   Src : TTextDocumentEdit absolute Source;
@@ -581,7 +590,7 @@ end;
 
 { TTextDocumentItem }
 
-procedure TTextDocumentItem.Assign(Source: TPersistent);
+procedure TTextDocumentItem.Assign(Source : TPersistent);
 
 var
   Src : TTextDocumentItem absolute Source;
@@ -626,7 +635,7 @@ begin
   inherited Destroy;
 end;
 
-procedure TTextDocumentPositionParams.Assign(Source: TPersistent);
+procedure TTextDocumentPositionParams.Assign(Source : TPersistent);
 
 var
   Src : TTextDocumentPositionParams absolute source;
@@ -661,7 +670,7 @@ begin
   inherited destroy;
 end;
 
-procedure TCommand.Assign(Source: TPersistent);
+procedure TCommand.Assign(Source : TPersistent);
 
 var
   Src : TCommand absolute Source;
@@ -679,13 +688,18 @@ end;
 
 { TPosition }
 
+constructor TPosition.Create;
+begin
+  Create(0,0);
+end;
+
 constructor TPosition.Create(l, c: integer);
 begin
   line := l;
   character := c;
 end;
 
-procedure TPosition.Assign(Source: TPersistent);
+procedure TPosition.Assign(Source : TPersistent);
 
 var
   Src : TPosition absolute source;
@@ -719,7 +733,7 @@ begin
   fRange := TRange.Create(Line, Column, Span);
 end;
 
-procedure TLocation.Assign(Source: TPersistent);
+procedure TLocation.Assign(Source : TPersistent);
 
 var
   Src : TLocation absolute source;
@@ -754,7 +768,7 @@ begin
   inherited destroy;
 end;
 
-procedure TLocationItem.Assign(source: TPersistent);
+procedure TLocationItem.Assign(Source : TPersistent);
 
 var
   Src : TLocationItem absolute source;
@@ -791,6 +805,7 @@ end;
 
 constructor TLocationLink.Create;
 begin
+  Inherited Create;
   fOriginSelectionRange:=TRange.Create;
   fTargetRange:=TRange.Create;
   fTargetSelectionRange:=TRange.Create;
@@ -804,7 +819,7 @@ begin
   inherited Destroy;
 end;
 
-procedure TLocationLink.Assign(aSource: TPersistent);
+procedure TLocationLink.Assign(aSource : TPersistent);
 
 var
   Src :  TLocationLink absolute aSource;
@@ -823,7 +838,7 @@ end;
 
 { TTextDocumentIdentifier }
 
-procedure TTextDocumentIdentifier.Assign(aSource: TPersistent);
+procedure TTextDocumentIdentifier.Assign(aSource : TPersistent);
 
 Var
   Src : TTextDocumentIdentifier absolute aSource;
@@ -839,7 +854,7 @@ end;
 
 { TVersionedTextDocumentIdentifier }
 
-procedure TVersionedTextDocumentIdentifier.Assign(aSource: TPersistent);
+procedure TVersionedTextDocumentIdentifier.Assign(aSource : TPersistent);
 
 Var
   Src : TVersionedTextDocumentIdentifier absolute aSource;
@@ -850,6 +865,12 @@ begin
     Version:=Src.Version;
     end;
   inherited Assign(aSource);
+end;
+
+destructor TVersionedTextDocumentIdentifier.Destroy;
+begin
+  FreeAndNil(fVersion);
+  inherited Destroy;
 end;
 
 { TRange }
@@ -866,22 +887,42 @@ begin
   fStart.Assign(AValue);
 end;
 
+constructor TRange.Create;
+begin
+  fStart := TPosition.Create(0,0);
+  fEnd := TPosition.Create(0,0);
+end;
+
 constructor TRange.Create(line, column: integer);
 begin
-  fStart := TPosition.Create(line, column);
-  fEnd := TPosition.Create(line, column);
+  Create;
+  SetRange(Line,Column,0);
 end;
 
 constructor TRange.Create(line, column, len: integer);
 begin
-  fStart := TPosition.Create(line, column);
-  fEnd := TPosition.Create(line, column + len);
+  Create;
+  SetRange(Line,Column,Len);
 end;
 
 constructor TRange.Create(startLine, startColumn: integer; endLine, endColumn: integer); overload;
 begin
-  fStart := TPosition.Create(startLine, startColumn);
-  fEnd := TPosition.Create(endLine, endColumn);
+  Create;
+  SetRange(startLine, startColumn,endLine, endColumn);
+end;
+
+procedure TRange.SetRange(line, column: integer; len: integer);
+begin
+  SetRange(Line,Column,Line,Column+Len);
+end;
+
+procedure TRange.SetRange(startLine, startColumn: integer; endLine,
+  endColumn: integer);
+begin
+  fStart.Line:=StartLine;
+  fStart.Character:=startColumn;
+  fEnd.Line:=endLine;
+  fEnd.Character:=endColumn;
 end;
 
 destructor TRange.destroy;
@@ -898,16 +939,33 @@ end;
 
 { TMarkupContent }
 
-constructor TMarkupContent.Create(content: string; plainText: boolean = true);
+function TMarkupContent.GetPlainText: Boolean;
 begin
-  value := content;
-  if plainText then
+  Result:=(Kind=TMarkupKind.PlainText)
+end;
+
+procedure TMarkupContent.SetPlainText(AValue: Boolean);
+begin
+  if aValue then
     kind := TMarkupKind.PlainText
   else
     kind := TMarkupKind.Markdown;
 end;
 
-procedure TMarkupContent.Assign(Source: TPersistent);
+constructor TMarkupContent.create;
+begin
+  inherited create;
+  kind:=TMarkupKind.PlainText
+end;
+
+constructor TMarkupContent.Create(content: string; _plainText: boolean = true);
+begin
+  Create;
+  value := content;
+  PlainText:=_plainText;
+end;
+
+procedure TMarkupContent.Assign(Source : TPersistent);
 
 var
   Src : TMarkupContent absolute source;
@@ -942,7 +1000,7 @@ begin
   inherited destroy;
 end;
 
-procedure TDiagnosticRelatedInformation.Assign(Source: TPersistent);
+procedure TDiagnosticRelatedInformation.Assign(Source : TPersistent);
 
 var
   Src : TDiagnosticRelatedInformation absolute source;
@@ -975,7 +1033,7 @@ begin
   inherited destroy;
 end;
 
-procedure TDiagnostic.Assign(Source: TPersistent);
+procedure TDiagnostic.Assign(Source : TPersistent);
 var
   Src : TDiagnostic absolute source;
 begin

--- a/src/protocol/LSP.DocumentSymbol.pas
+++ b/src/protocol/LSP.DocumentSymbol.pas
@@ -142,9 +142,13 @@ type
 
   { TDocumentSymbolParams }
 
-  TDocumentSymbolParams = class(TPersistent)
+  TDocumentSymbolParams = class(TLSPStreamable)
   private
     fTextDocument: TTextDocumentIdentifier;
+  public
+    Constructor Create; override;
+    Destructor Destroy; override;
+    Procedure Assign(Source: TPersistent); override;
   published
     // The text document.
     property textDocument: TTextDocumentIdentifier read fTextDocument write fTextDocument;
@@ -158,7 +162,7 @@ type
       Then neither the symbol’s location range nor the symbol’s container name should be used to infer a hierarchy.
     * DocumentSymbol[] which is a hierarchy of symbols found in a given text document. }
 
-  TDocumentSymbolRequest = class(specialize TLSPRequest<TDocumentSymbolParams, TPersistent>)
+  TDocumentSymbolRequest = class(specialize TLSPRequest<TDocumentSymbolParams, TLSPStreamable>)
     function DoExecute(const Params: TJSONData; AContext: TJSONRPCCallContext): TJSONData; override;
   end;
 
@@ -237,6 +241,32 @@ begin
   else if (kind = 'Event') then result := TSymbolKind._Event
   else if (kind = 'Operator') then result := TSymbolKind._Operator
   else if (kind = 'TypeParameter') then result := TSymbolKind._TypeParameter
+end;
+
+{ TDocumentSymbolParams }
+
+constructor TDocumentSymbolParams.Create;
+begin
+  inherited Create;
+  fTextDocument:=TTextDocumentIdentifier.Create;
+end;
+
+destructor TDocumentSymbolParams.Destroy;
+begin
+  FreeAndNil(fTextDocument);
+  inherited Destroy;
+end;
+
+procedure TDocumentSymbolParams.Assign(Source: TPersistent);
+var
+  Src: TDocumentSymbolParams absolute Source;
+begin
+  if Source is TDocumentSymbolParams then
+    begin
+      textDocument.Assign(Src.textDocument);
+    end
+  else
+    inherited Assign(Source);
 end;
 
 { TDocumentSymbolRequest }

--- a/src/protocol/LSP.GotoDeclaration.pas
+++ b/src/protocol/LSP.GotoDeclaration.pas
@@ -63,7 +63,7 @@ begin with Params do
     else
       begin
         Result := nil;
-        PublishDiagnostic;
+        PublishDiagnostic(Transport,'');
       end;
   end;
 end;

--- a/src/protocol/LSP.GotoDefinition.pas
+++ b/src/protocol/LSP.GotoDefinition.pas
@@ -81,7 +81,7 @@ begin with Params do
     else
       begin
         Result := nil;
-        PublishDiagnostic;
+        PublishDiagnostic(Transport);
       end;
   end;
 end;

--- a/src/protocol/LSP.GotoImplementation.pas
+++ b/src/protocol/LSP.GotoImplementation.pas
@@ -65,7 +65,7 @@ begin with Params do
       end
     else
       begin
-        PublishDiagnostic;
+        PublishDiagnostic(Transport);
         Result := nil;
       end;
   end;

--- a/src/protocol/LSP.Options.pas
+++ b/src/protocol/LSP.Options.pas
@@ -47,10 +47,11 @@ type
 
   { TSaveOptions }
 
-  TSaveOptions = class(TPersistent)
+  TSaveOptions = class(TLSPStreamable)
   private
     fIncludeText: Boolean;
   public
+    Constructor Create; override;
     constructor Create(_includeText: boolean);
     Procedure Assign(aSource : TPersistent); override;
   published
@@ -60,7 +61,7 @@ type
 
   { TTextDocumentSyncOptions }
 
-  TTextDocumentSyncOptions = class(TPersistent)
+  TTextDocumentSyncOptions = class(TLSPStreamable)
   private
     fOpenClose: Boolean;
     fChange: TTextDocumentSyncKind;
@@ -69,7 +70,7 @@ type
     fSave: TSaveOptions;
     procedure SetSave(AValue: TSaveOptions);
   public
-    constructor Create;
+    constructor Create; override;
     destructor destroy; override;
     Procedure Assign(aSource : TPersistent); override;
   published
@@ -94,12 +95,12 @@ type
 
   { TSignatureHelpOptions }
   
-  TSignatureHelpOptions = class(TPersistent)
+  TSignatureHelpOptions = class(TLSPStreamable)
   private
     fTriggerCharacters: TStrings;
     procedure SetTriggerCharacters(AValue: TStrings);
   Public
-    Constructor Create;
+    Constructor Create; override;
     Destructor Destroy; override;
     Procedure Assign(Source : TPersistent); override;
   published
@@ -109,13 +110,13 @@ type
 
   { TCompletionOptions }
 
-  TCompletionOptions = class(TPersistent)
+  TCompletionOptions = class(TLSPStreamable)
   private
     fTriggerCharacters: TStrings;
     fAllCommitCharacters: TStrings;
     fResolveProvider: Boolean;
   public
-    constructor Create;
+    constructor Create; override;
     destructor destroy; override;
     procedure Assign(Source : TPersistent); override;
   published
@@ -150,7 +151,7 @@ type
 
   { TWorkDoneProgressOptions }
   
-  TWorkDoneProgressOptions = class(TPersistent)
+  TWorkDoneProgressOptions = class(TLSPStreamable)
   private
     fworkDoneProgress: TOptionalBoolean;
   Public
@@ -166,6 +167,7 @@ type
     fCommands: TStrings;
     procedure SetCommands(AValue: TStrings);
   public
+    constructor Create; override;
     constructor Create(_commands: TStringArray);
     destructor destroy; override;
     Procedure Assign(Source : TPersistent); override;
@@ -194,11 +196,17 @@ begin
   fCommands.Assign(AValue);
 end;
 
+constructor TExecuteCommandOptions.Create;
+begin
+  inherited Create;
+  FCommands := TStringList.Create;
+end;
+
 constructor TExecuteCommandOptions.Create(_commands: TStringArray);
 var
   command: String;
 begin
-  FCommands := TStringList.Create;
+  Create;
   for command in _commands do
     commands.Add(command);
 end;
@@ -224,6 +232,11 @@ begin
 end;
 
 { TSaveOptions }
+
+constructor TSaveOptions.Create;
+begin
+  fincludeText:=False;
+end;
 
 constructor TSaveOptions.Create(_includeText: boolean);
 begin
@@ -254,6 +267,7 @@ end;
 
 constructor TTextDocumentSyncOptions.Create;
 begin
+  Inherited Create;
   openClose := True;
   change := TTextDocumentSyncKind.Full;
   fSave:=TSaveOptions.Create(False);
@@ -293,6 +307,7 @@ end;
 
 constructor TSignatureHelpOptions.Create;
 begin
+  Inherited Create;
   fTriggerCharacters:=TStringList.Create;
 end;
 
@@ -320,6 +335,7 @@ end;
 
 constructor TCompletionOptions.Create;
 begin
+  Inherited Create;
   resolveProvider := False;
   fTriggerCharacters:=TStringList.Create;
   fAllCommitCharacters:=TStringList.Create;

--- a/src/protocol/LSP.Streaming.pas
+++ b/src/protocol/LSP.Streaming.pas
@@ -126,16 +126,12 @@ begin
           end;
           end;
       finally
-        FReeAndNil(Pil);
+        FreeAndNil(Pil);
       end;
       // TODO: StreamChildren is private so we can't support it
       If (jsoStreamChildren in Options) and (AObject is TComponent) then
-        begin
           //Result.Add(ChildProperty,StreamChildren(TComponent(AObject)));
-          writeln(StdErr, 'jsoStreamChildren not supported');
-          Flush(StdErr);
-          Halt(-1);
-        end;
+          Raise Exception.Create('jsoStreamChildren not supported');
       If Assigned(AfterStreamObject) then
         AfterStreamObject(Self,AObject,Result);
       end;
@@ -279,6 +275,7 @@ begin
     inherited DoRestoreProperty(AObject, PropInfo, PropData)
 end;
 
+
 { TLSPStreaming }
 
 class procedure TLSPStreaming.GetObject(Sender: TOBject; AObject: TObject;
@@ -288,7 +285,8 @@ var
   C: TClass;
 begin
   C := GetTypeData(Info^.PropType)^.ClassType;
-  if C.InheritsFrom(TPersistent) then AValue := C.Create;
+  if C.InheritsFrom(TLSPStreamable) then
+    AValue := TLSPStreamableClass(C).Create;
 end;
 
 class constructor TLSPStreaming.Create;

--- a/src/protocol/LSP.Window.pas
+++ b/src/protocol/LSP.Window.pas
@@ -25,7 +25,7 @@ interface
 
 uses
   { RTL }
-  Classes, 
+  SysUtils, Classes,
   { Code Tools }
   CodeToolManager,
   { Protocol }
@@ -45,7 +45,7 @@ type
 
   { TShowMessageParams }
 
-  TShowMessageParams = class(TPersistent)
+  TShowMessageParams = class(TLSPStreamable)
   private
     fType: TMessageType;
     fMessage: string;
@@ -64,6 +64,7 @@ type
 
   TShowMessageNotification = class(TNotificationMessage)
   public
+    constructor Create; override;
     constructor Create(_type: TMessageType; Message: String);
     destructor Destroy; override;
   end;
@@ -78,23 +79,32 @@ type
 
   TMessageActionItems = specialize TGenericCollection<TMessageActionItem>;
 
-  { TShowMessageRequstParams }
+  { TShowMessageRequestParams }
 
-  TShowMessageRequstParams = class(TShowMessageParams)
+  TShowMessageRequestParams = class(TShowMessageParams)
   private
     fActions: TMessageActionItems;
+    procedure SetActions(AValue: TMessageActionItems);
   published
+    Constructor Create; override;
+    Destructor Destroy; override;
     // The message action items to present.
-    property actions: TMessageActionItems read fActions write fActions;
+    property actions: TMessageActionItems read fActions write SetActions;
   end;
 
 implementation
 
 { TShowMessageNotification }
 
+constructor TShowMessageNotification.Create;
+begin
+  inherited Create;
+  params := TShowMessageParams.Create;
+end;
+
 constructor TShowMessageNotification.Create(_type: TMessageType; Message: String);
 begin
-  params := TShowMessageParams.Create;
+  Create;
   TShowMessageParams(params).&type := _type;
   TShowMessageParams(params).message := Message;
   method := 'window/showMessage';
@@ -104,6 +114,26 @@ destructor TShowMessageNotification.Destroy;
 begin
   params.Free;
   inherited;
+end;
+
+{ TShowMessageRequstParams }
+
+procedure TShowMessageRequestParams.SetActions(AValue: TMessageActionItems);
+begin
+  if fActions=AValue then Exit;
+  fActions.Assign(AValue);
+end;
+
+constructor TShowMessageRequestParams.Create;
+begin
+  inherited Create;
+  fActions:=TMessageActionItems.Create;
+end;
+
+destructor TShowMessageRequestParams.Destroy;
+begin
+  FreeAndNil(fActions);
+  inherited Destroy;
 end;
 
 end.

--- a/src/protocol/LSP.WorkDoneProgress.pas
+++ b/src/protocol/LSP.WorkDoneProgress.pas
@@ -25,13 +25,13 @@ unit LSP.WorkDoneProgress;
 interface
 uses
   { RTL }
-  Classes;
+  Classes, LSP.BaseTypes;
 
 type
   TProgressToken = String; { integer | string }
 
 type
-  TWorkDoneProgressParams = class(TPersistent)
+  TWorkDoneProgressParams = class(TLSPStreamable)
     private
       fWorkDoneToken: TProgressToken;
     published

--- a/src/protocol/LSP.Workspace.pas
+++ b/src/protocol/LSP.Workspace.pas
@@ -34,10 +34,14 @@ type
   
   { TWorkspaceFoldersChangeEvent }
 
-  TWorkspaceFoldersChangeEvent = class(TPersistent)
+  TWorkspaceFoldersChangeEvent = class(TLSPStreamable)
   private
     fAdded: TWorkspaceFolderItems;
     fRemoved: TWorkspaceFolderItems;
+  Public
+    constructor Create; override;
+    destructor Destroy; override;
+    procedure Assign(Source: TPersistent); override;
   published
     // The array of added workspace folders
     property added: TWorkspaceFolderItems read fAdded write fAdded;
@@ -47,11 +51,16 @@ type
 
   { TDidChangeWorkspaceFoldersParams }
 
-  TDidChangeWorkspaceFoldersParams = class(TPersistent)
+  TDidChangeWorkspaceFoldersParams = class(TLSPStreamable)
   private
     fEvent: TWorkspaceFoldersChangeEvent;
+    procedure SetEvent(AValue: TWorkspaceFoldersChangeEvent);
+  Public
+    constructor Create; override;
+    destructor Destroy; override;
+    procedure Assign(Source: TPersistent); override;
   published
-    property event: TWorkspaceFoldersChangeEvent read fEvent write fEvent;
+    property event: TWorkspaceFoldersChangeEvent read fEvent write SetEvent;
   end;
 
   { TDidChangeWorkspaceFolders }
@@ -71,9 +80,13 @@ type
 
   { The parameters of a Workspace Symbol Request. }
 
-  TWorkspaceSymbolParams = class(TPersistent)
+  { TWorkspaceSymbolParams }
+
+  TWorkspaceSymbolParams = class(TLSPStreamable)
   private
     fQuery: string;
+  Public
+    Procedure Assign(Source: TPersistent); override;
   published
     // A query string to filter symbols by. Clients may send an empty
     // string here to request all symbols.
@@ -91,11 +104,16 @@ type
 
   { TDidChangeConfigurationParams }
 
-  TDidChangeConfigurationParams = class(TPersistent)
+  TDidChangeConfigurationParams = class(TLSPStreamable)
   private
     fSettings: TServerSettings;
+    procedure SetSettings(AValue: TServerSettings);
+  Public
+    Constructor Create; override;
+    Destructor Destroy; override;
+    Procedure Assign(Source: TPersistent); override;
   published
-    property settings: TServerSettings read fSettings write fSettings;
+    property settings: TServerSettings read fSettings write SetSettings;
   end;
 
   { TDidChangeConfiguration }
@@ -108,27 +126,36 @@ type
 
   { TApplyWorkspaceEditParams }
 
-  TApplyWorkspaceEditParams = class(TPersistent)
+  TApplyWorkspaceEditParams = class(TLSPStreamable)
   private
     fLabel: TOptionalString;
     fEdit: TWorkspaceEdit;
+    procedure SetEdit(AValue: TWorkspaceEdit);
+    procedure SetLabel(AValue: TOptionalString);
+  Public
+    Constructor Create; override;
+    Destructor Destroy; override;
+    Procedure Assign(Source : TPersistent); override;
   published
     // An optional label of the workspace edit. This label is
     // presented in the user interface for example on an undo
     // stack to undo the workspace edit.
-    property &label: TOptionalString read fLabel write fLabel;
+    // Once set, the instance owns the value
+    property &label: TOptionalString read fLabel write SetLabel;
     //  The edits to apply.
-    property edit: TWorkspaceEdit read fEdit write fEdit;
+    property edit: TWorkspaceEdit read fEdit write SetEdit;
   end;
 
   { TApplyWorkspaceEditResult
     https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#applyWorkspaceEditResult }
 
-  TApplyWorkspaceEditResult = class(TPersistent)
+  TApplyWorkspaceEditResult = class(TLSPStreamable)
   private
     fApplied: boolean;
     fFailureReason: TOptionalString;
     fFailedChange: TOptionalNumber;
+  Public
+    Destructor Destroy; override;
   published
     // Indicates whether the edit was applied or not.
     property applied: Boolean read fApplied write fApplied;
@@ -161,10 +188,138 @@ procedure TDidChangeConfiguration.Process(var Params: TDidChangeConfigurationPar
 begin
 end;
 
+{ TApplyWorkspaceEditParams }
+
+procedure TApplyWorkspaceEditParams.SetEdit(AValue: TWorkspaceEdit);
+begin
+  if fEdit=AValue then Exit;
+  fEdit.Assign(AValue);
+end;
+
+procedure TApplyWorkspaceEditParams.SetLabel(AValue: TOptionalString);
+begin
+  if fLabel=AValue then Exit;
+  FreeAndNil(fLabel);
+  fLabel:=AValue;
+end;
+
+constructor TApplyWorkspaceEditParams.Create;
+begin
+  inherited Create;
+  fEdit:=TWorkspaceEdit.Create;
+end;
+
+destructor TApplyWorkspaceEditParams.Destroy;
+begin
+  &Label:=Nil;
+  edit:=Nil;
+  inherited Destroy;
+end;
+
+procedure TApplyWorkspaceEditParams.Assign(Source: TPersistent);
+var
+  Src: TApplyWorkspaceEditParams absolute source;
+begin
+  if Source is TApplyWorkspaceEditParams then
+    begin
+    Edit.Assign(Src.Edit);
+    if Assigned(Src.&Label) then
+      fLabel.Value:=Src.&Label.Value;
+    end
+  else
+    inherited Assign(Source);
+end;
+
+{ TApplyWorkspaceEditResult }
+
+destructor TApplyWorkspaceEditResult.Destroy;
+begin
+  FreeAndnil(fFailureReason);
+  FreeAndnil(fFailedChange);
+  inherited Destroy;
+end;
+
+{ TWorkspaceFoldersChangeEvent }
+
+constructor TWorkspaceFoldersChangeEvent.Create;
+begin
+  inherited Create;
+  fAdded:=TWorkspaceFolderItems.Create;
+  fRemoved:=TWorkspaceFolderItems.Create;
+end;
+
+destructor TWorkspaceFoldersChangeEvent.Destroy;
+begin
+  FreeAndNil(fAdded);
+  FreeAndNil(fRemoved);
+  inherited Destroy;
+end;
+
+procedure TWorkspaceFoldersChangeEvent.Assign(Source: TPersistent);
+var
+  Src: TWorkspaceFoldersChangeEvent absolute Source;
+begin
+  if Source is TWorkspaceFoldersChangeEvent then
+    begin
+      Added.Assign(Src.Added);
+      Removed.Assign(Src.Removed);
+    end
+  else
+    inherited Assign(Source);
+end;
+
+{ TDidChangeWorkspaceFoldersParams }
+
+procedure TDidChangeWorkspaceFoldersParams.SetEvent(
+  AValue: TWorkspaceFoldersChangeEvent);
+begin
+  if fEvent=AValue then Exit;
+  fEvent.Assign(AValue);
+end;
+
+constructor TDidChangeWorkspaceFoldersParams.Create;
+begin
+  inherited Create;
+  fEvent:=TWorkspaceFoldersChangeEvent.Create;
+end;
+
+destructor TDidChangeWorkspaceFoldersParams.Destroy;
+begin
+  FreeAndNil(fEvent);
+  inherited Destroy;
+end;
+
+procedure TDidChangeWorkspaceFoldersParams.Assign(Source: TPersistent);
+var
+  Src: TDidChangeWorkspaceFoldersParams absolute Source;
+begin
+  if Source is TDidChangeWorkspaceFoldersParams then
+    begin
+      Event.Assign(Src.event)
+    end
+  else
+    inherited Assign(Source);
+end;
+
 { TDidChangeWorkspaceFolders }
 
 procedure TDidChangeWorkspaceFolders.Process(var Params : TDidChangeWorkspaceFoldersParams);
 begin
+end;
+
+{ TWorkspaceSymbolParams }
+
+procedure TWorkspaceSymbolParams.Assign(Source: TPersistent);
+var
+  Src: TWorkspaceSymbolParams;
+
+begin
+  if Source is TWorkspaceSymbolParams then
+    begin
+      Query:=Src.query;
+    end
+  else
+    inherited Assign(Source);
 end;
 
 { TWorkspaceSymbolRequest }
@@ -176,11 +331,42 @@ var
 begin
   Input := specialize TLSPStreaming<TWorkspaceSymbolParams>.ToObject(Params);
   Result := SymbolManager.FindWorkspaceSymbols(Input.query);
-  Flush(stderr);
-
   if not Assigned(Result) then
     Result := TJSONNull.Create;
 end;
+
+{ TDidChangeConfigurationParams }
+
+procedure TDidChangeConfigurationParams.SetSettings(AValue: TServerSettings);
+begin
+  if fSettings=AValue then Exit;
+  fSettings.Assign(AValue);
+end;
+
+constructor TDidChangeConfigurationParams.Create;
+begin
+  inherited Create;
+  fSettings:=TServerSettings.Create;
+end;
+
+destructor TDidChangeConfigurationParams.Destroy;
+begin
+  FreeAndNil(FSettings);
+  inherited Destroy;
+end;
+
+procedure TDidChangeConfigurationParams.Assign(Source: TPersistent);
+var
+  Src: TDidChangeConfigurationParams absolute source;
+begin
+  if Source is TDidChangeConfigurationParams then
+    begin
+       Settings.Assign(Src.settings);
+    end
+  else
+    inherited Assign(Source);
+end;
+
 
 initialization
   LSPHandlerManager.RegisterHandler('workspace/didChangeConfiguration', TDidChangeConfiguration);

--- a/src/protocol/PasLS.CodeUtils.pas
+++ b/src/protocol/PasLS.CodeUtils.pas
@@ -30,7 +30,7 @@ uses
   { CodeTools }
   CodeCache, CodeTree, PascalReaderTool, PascalParserTool, IdentCompletionTool, BasicCodeTools,
   { Pasls }
-  LSP.Basic;
+  LSP.Basic, LSP.Messages;
 
 type
   
@@ -243,18 +243,17 @@ begin
   end;
 end;
 
-procedure PrintIdentifierTree(Identifier: TIdentifierListItem);
+procedure PrintIdentifierTree(aTransport : TMessageTransport; Identifier: TIdentifierListItem);
 var
   Node: TCodeTreeNode;
   Details: ShortString;
   ObjectMember: boolean;
 begin
-  writeln(StdErr, Identifier.Identifier, ' -> ', IdentifierContext(Identifier, Details, ObjectMember));
+  aTransport.SendDiagnostic('%s -> %s',[Identifier.Identifier, IdentifierContext(Identifier, Details, ObjectMember)]);
   Node := Identifier.Node;
   while Node <> nil do
     begin
-      writeln(StdErr, '  ', Node.DescAsString, ' children=', Node.ChildCount);
-      writeln(StdErr);
+      aTransport.SendDiagnostic('  %s children=%d', [Node.DescAsString, Node.ChildCount]);
       Node := Node.Parent;
     end;
 end;

--- a/src/protocol/PasLS.Settings.pas
+++ b/src/protocol/PasLS.Settings.pas
@@ -24,7 +24,7 @@ unit PasLS.Settings;
 
 interface
 uses
-  Classes, FGL;
+  Classes, FGL, LSP.BaseTypes;
 
 { Global String Constants }
 const
@@ -42,7 +42,7 @@ type
 
   { TServerSettings }
 
-  TServerSettings = class(TPersistent)
+  TServerSettings = class(TLSPStreamable)
   private
     fBooleans: array[0..32] of Boolean;
     fProgram: String;
@@ -96,7 +96,7 @@ type
 
     function CanProvideWorkspaceSymbols: boolean;
   public
-    constructor Create;
+    constructor Create; override;
     Destructor Destroy; override;
     procedure ReplaceMacros(Macros: TMacroMap);
     Procedure Assign(aSource : TPersistent); override;
@@ -104,7 +104,7 @@ type
 
   { TClientInfo }
 
-  TClientInfo = class(TPersistent)
+  TClientInfo = class(TLSPStreamable)
   private
     fName: string;
     fVersion: string;
@@ -119,7 +119,7 @@ type
 
   { TConfigEnvironmentSettings }
 
-  TConfigEnvironmentSettings = class(TPersistent)
+  TConfigEnvironmentSettings = class(TLSPStreamable)
   Private
     ffpcDir: string;
     ffpcTarget: string;
@@ -127,7 +127,7 @@ type
     flazarusDir: string;
     fpp: string;
   Public
-    Constructor Create;
+    Constructor Create; override;
     Procedure Assign(aSource : TPersistent); override;
   published
     property fpcDir : string Read ffpcDir Write ffpcDir;
@@ -215,7 +215,7 @@ begin
     end;
 end;
 
-procedure TServerSettings.Assign(aSource: TPersistent);
+procedure TServerSettings.Assign(aSource : TPersistent);
 
 var
   src : TServerSettings absolute aSource;
@@ -283,7 +283,7 @@ end;
 
 { TClientInfo }
 
-procedure TClientInfo.Assign(aSource: TPersistent);
+procedure TClientInfo.Assign(aSource : TPersistent);
 
 var
   Src : TClientInfo absolute aSource;
@@ -317,7 +317,7 @@ begin
   MaybeSet('FPCTARGETCPU',ffpcTargetCPU);
 end;
 
-procedure TConfigEnvironmentSettings.Assign(aSource: TPersistent);
+procedure TConfigEnvironmentSettings.Assign(aSource : TPersistent);
 var
   src : TConfigEnvironmentSettings absolute aSource;
 begin

--- a/src/proxy/paslsproxy.lpi
+++ b/src/proxy/paslsproxy.lpi
@@ -4,6 +4,7 @@
     <Version Value="12"/>
     <General>
       <Flags>
+        <SaveOnlyProjectUnits Value="True"/>
         <MainUnitHasCreateFormStatements Value="False"/>
         <MainUnitHasTitleStatement Value="False"/>
         <MainUnitHasScaledStatement Value="False"/>

--- a/src/standard/pasls.lpi
+++ b/src/standard/pasls.lpi
@@ -5,6 +5,8 @@
     <General>
       <Flags>
         <MainUnitHasCreateFormStatements Value="False"/>
+        <MainUnitHasTitleStatement Value="False"/>
+        <MainUnitHasScaledStatement Value="False"/>
         <CompatibilityMode Value="True"/>
       </Flags>
       <SessionStorage Value="InProjectDir"/>
@@ -66,6 +68,9 @@
   </ProjectOptions>
   <CompilerOptions>
     <Version Value="11"/>
+    <Target>
+      <Filename Value="pasls"/>
+    </Target>
     <SearchPaths>
       <IncludeFiles Value="$(ProjOutDir)"/>
       <UnitOutputDirectory Value="lib/$(TargetCPU)-$(TargetOS)"/>

--- a/src/standard/pasls.lpr
+++ b/src/standard/pasls.lpr
@@ -25,7 +25,7 @@ program pasls;
 uses
   { RTL }
 
-  SysUtils, Classes, FPJson, JSONParser, JSONScanner, MemUtils,
+  SysUtils, Classes, FPJson, JSONParser, JSONScanner,
   { Protocol }
   LSP.AllCommands,
   LSP.Base, LSP.Basic, PasLS.TextLoop;
@@ -61,7 +61,9 @@ begin
 end;
 
 var
+  aTransport : TLSPTextTransport;
   aContext : TLSPContext;
+  aDisp : TLSPLocalDispatcher;
 
 begin
   // Show help for the server
@@ -70,14 +72,15 @@ begin
     writeln('Pascal Language Server [',{$INCLUDE %DATE%},']');
     Halt;
     end;
-  SetupTextLoop;
-  aContext:=TLSPContext.Create(TLSPLocalDispatcher.Create(),True);
+  SetupTextLoop(Input,Output,StdErr);
+  aTransport:=TLSPTextTransport.Create(@Input,@StdErr);
+  aDisp:=TLSPLocalDispatcher.Create(aTransport,True);
+  aContext:=TLSPContext.Create(aTransport,aDisp,True);
   try
     if not ExecuteCommandLineMessages(aContext) then
       exit;
     RunMessageLoop(Input,Output,StdErr,aContext);
    Finally
      aContext.Free;
-     DrainAutoReleasePool;
    end;
 end.


### PR DESCRIPTION
Ryan,

This patch introduces the transport layer for exchanging messages.
Now diagnostic messages from the socket server will be sent over the socket  to the client.

In the StdIO client, the transport layer simply uses Writeln(StdErr) or Writeln(Output) to send messages.

It means you may no longer simply use Writeln(StdErr) or Writeln(Output), but always use the Transport.SendDiagnostic() or send a message. 

After this change, we should be able to create the 'standard' socket based protocol, and all should simply continue to function.

I was able to fix also heaps of memory leaks, now the application is leaking considerably less memory :smiley: 