### PR TITLE
Memleak fixes

### DIFF
--- a/src/protocol/LSP.Basic.pas
+++ b/src/protocol/LSP.Basic.pas
@@ -93,6 +93,7 @@ type
   public
     constructor Create; override;
     constructor Create(Path: String; Line, Column, Span: Integer); overload;
+    Destructor Destroy; override;
     procedure Assign(Source : TPersistent); override;
   published
     property uri: TDocumentUri read fUri write fUri;
@@ -695,6 +696,7 @@ end;
 
 constructor TPosition.Create(l, c: integer);
 begin
+  Inherited Create;
   line := l;
   character := c;
 end;
@@ -731,6 +733,12 @@ constructor TLocation.Create(Path: String; Line, Column, Span: Integer);
 begin
   uri := PathToURI(Path);
   fRange := TRange.Create(Line, Column, Span);
+end;
+
+destructor TLocation.Destroy;
+begin
+  FreeAndNil(Frange);
+  inherited Destroy;
 end;
 
 procedure TLocation.Assign(Source : TPersistent);

--- a/src/protocol/LSP.SignatureHelp.pas
+++ b/src/protocol/LSP.SignatureHelp.pas
@@ -305,7 +305,7 @@ var
   CodeContext: TCodeContextInfo;
   Item: TCodeContextInfoItem;
   Signature: TSignatureInformation;
-  Parameters: TParameterInformationCollection;
+
   Parameter: TParameterInformation;
   Head: String;
   ParamList: TStringList;
@@ -326,7 +326,6 @@ begin
         end;
 
       Result := TSignatureHelp.Create;
-      Result.signatures := TSignatureInformationCollection.Create;
 
       // TODO: how do we know which one is active given the current parameters?
       Result.activeSignature := 0;
@@ -341,13 +340,11 @@ begin
 
           if ParamList <> nil then
             begin
-              Parameters := TParameterInformationCollection.Create;
               for I := 0 to ParamList.Count - 1 do
                 begin
-                  Parameter := TParameterInformation(Parameters.Add);
+                  Parameter := Signature.Parameters.Add;
                   Parameter.&label := ParamList[I];
                 end;
-              Signature.parameters := Parameters;
               ParamList.Free;
             end;
         end;

--- a/src/protocol/LSP.Streaming.pas
+++ b/src/protocol/LSP.Streaming.pas
@@ -32,7 +32,7 @@ type
 
   { TLSPStreaming }
 
-  generic TLSPStreaming<T> = class
+  generic TLSPStreaming<T: TPersistent> = class
   type
     PObject = ^TObject;
   private

--- a/src/protocol/PasLS.Settings.pas
+++ b/src/protocol/PasLS.Settings.pas
@@ -336,4 +336,5 @@ end;
 finalization
   _ServerSettings.Free;
   _ClientInfo.Free;
+  _EnvironmentSettings.Free;
 end.


### PR DESCRIPTION
Ryan,

This patch fixes memleaks for the following commands:
- Document symbols
- Parameter hints
- Find References
Plus some memleak in TLocation.

I can now actually work for a prolonged time and not have any memory leaks.
