### PR TITLE
* Allow to use fcl-passrc parser on current code buffer

### DIFF
--- a/src/protocol/LSP.Synchronization.pas
+++ b/src/protocol/LSP.Synchronization.pas
@@ -297,7 +297,7 @@ begin with Params do
     if SymbolManager <> nil then
       SymbolManager.FileModified(Code);
     CheckSyntax(Transport,Code);
-    ClearDiagnostics(Transport,Code);
+    // ClearDiagnostics(Transport,Code);
   end;
 end;
 
@@ -400,6 +400,9 @@ begin with Params do
           end
         else }
         Code.Source := TTextDocumentContentChangeEvent(Change).text;
+
+        // Ryan, uncomment this to have a syntax check at
+        // CheckSyntax(Self.Transport,Code);
 
         //if SymbolManager <> nil then
         //  SymbolManager.FileModified(Code);

--- a/src/protocol/PasLS.Parser.pas
+++ b/src/protocol/PasLS.Parser.pas
@@ -155,7 +155,11 @@ begin
       Scanner.AddDefine(s);
       Case s of
         'LINUX' : Scanner.AddDefine('UNIX');
-        'DARWIN' : Scanner.AddDefine('UNIX');
+        'DARWIN' :
+          begin
+          Scanner.AddDefine('DARWIN');
+          Scanner.AddDefine('UNIX');
+          end;
         'FREEBSD' :
           begin
           Scanner.AddDefine('BSD');

--- a/src/protocol/PasLS.Parser.pas
+++ b/src/protocol/PasLS.Parser.pas
@@ -1,0 +1,241 @@
+unit PasLS.Parser;
+
+{$mode objfpc}{$H+}
+
+interface
+
+uses
+  Classes, SysUtils, PParser, PScanner, PasTree, CodeCache;
+
+Type
+
+ { TCodeToolsFileResolver }
+
+  TCodeToolsFileResolver = Class(TFileResolver)
+  Private
+    FBuffer: TCodeBuffer;
+  Protected
+    function CreateLineReaderFromBuffer(aBuffer: TCodeBuffer): TLineReader;
+  Public
+    Constructor Create(aBuffer : TCodeBuffer);
+    function FindSourceFile(const AName: string): TLineReader; override;
+    Property Buffer : TCodeBuffer read FBuffer;
+  end;
+
+  { TSimpleEngine }
+
+  TSimpleEngine = class(TPasTreeContainer)
+  public
+    function CreateElement(AClass: TPTreeElement; const AName: String;
+      AParent: TPasElement; AVisibility: TPasMemberVisibility;
+      const ASourceFilename: String; ASourceLinenumber: Integer): TPasElement;
+      override;
+    function FindElement(const AName: String): TPasElement; override;
+  end;
+
+function ParseSource(const FPCCommandLine : Array of String;
+                     const Code : TCodeBuffer;
+                     OSTarget, CPUTarget: String;
+                     Options : TParseSourceOptions): TPasModule;
+
+
+implementation
+
+uses CodeToolManager;
+
+{ Checks syntax for code buffer and publishes errors as diagnostics }
+
+{ TSimpleEngine }
+
+function TSimpleEngine.CreateElement(AClass: TPTreeElement; const AName: String;
+  AParent: TPasElement; AVisibility: TPasMemberVisibility;
+  const ASourceFilename: String; ASourceLinenumber: Integer): TPasElement;
+begin
+  Result := AClass.Create(AName, AParent);
+  Result.Visibility := AVisibility;
+  Result.SourceFilename := ASourceFilename;
+  Result.SourceLinenumber := ASourceLinenumber;
+end;
+
+function TSimpleEngine.FindElement(const AName: String): TPasElement;
+
+begin
+  // We could try to use codetools for this.
+  Result := nil;
+end;
+
+
+function ParseSource(const FPCCommandLine : Array of String;
+                     const Code : TCodeBuffer;
+                     OSTarget, CPUTarget: String;
+                     Options : TParseSourceOptions): TPasModule;
+
+var
+  FileResolver: TBaseFileResolver;
+  Parser: TPasParser;
+  Filename: String;
+  Scanner: TPascalScanner;
+
+  procedure ProcessCmdLinePart(S : String);
+  var
+    l,Len: Integer;
+
+  begin
+    if (S='') then
+      exit;
+    Len:=Length(S);
+    if (s[1] = '-') and (len>1) then
+    begin
+      case s[2] of
+        'd': // -d define
+          Scanner.AddDefine(UpperCase(Copy(s, 3, Len)));
+        'u': // -u undefine
+          Scanner.RemoveDefine(UpperCase(Copy(s, 3, Len)));
+        'F': // -F
+          if (len>2) and (s[3] = 'i') then // -Fi include path
+            FileResolver.AddIncludePath(Copy(s, 4, Len));
+        'I': // -I include path
+          FileResolver.AddIncludePath(Copy(s, 3, Len));
+        'S': // -S mode
+          if  (len>2) then
+            begin
+            l:=3;
+            While L<=Len do
+              begin
+              case S[l] of
+                'c' : Scanner.Options:=Scanner.Options+[po_cassignments];
+                'd' : Scanner.SetCompilerMode('DELPHI');
+                '2' : Scanner.SetCompilerMode('OBJFPC');
+                'h' : ; // do nothing
+              end;
+              inc(l);
+              end;
+            end;
+        'M' :
+           begin
+           delete(S,1,2);
+           Scanner.SetCompilerMode(S);
+           end;
+      end;
+    end else
+      if Filename <> '' then
+        raise ENotSupportedException.Create(SErrMultipleSourceFiles)
+      else
+        Filename := s;
+  end;
+
+var
+  S: String;
+  Engine : TSimpleEngine;
+
+begin
+  if DefaultFileResolverClass=Nil then
+    raise ENotImplemented.Create(SErrFileSystemNotSupported);
+  Result := nil;
+  FileResolver := nil;
+  Scanner := nil;
+  Parser := nil;
+  Engine:=Nil;
+  try
+    Engine:=TSimpleEngine.Create;
+    FileResolver := TCodeToolsFileResolver.Create(Code);
+    {$ifdef HasStreams}
+    if FileResolver is TFileResolver then
+      TFileResolver(FileResolver).UseStreams:=poUseStreams in Options;
+    {$endif}
+    Scanner := TPascalScanner.Create(FileResolver);
+    Scanner.LogEvents:=Engine.ScannerLogEvents;
+    Scanner.OnLog:=Engine.Onlog;
+    if not (poSkipDefaultDefs in Options) then
+      begin
+      Scanner.AddDefine('FPK');
+      Scanner.AddDefine('FPC');
+      // TargetOS
+      s := UpperCase(OSTarget);
+      Scanner.AddDefine(s);
+      Case s of
+        'LINUX' : Scanner.AddDefine('UNIX');
+        'FREEBSD' :
+          begin
+          Scanner.AddDefine('BSD');
+          Scanner.AddDefine('UNIX');
+          end;
+        'NETBSD' :
+          begin
+          Scanner.AddDefine('BSD');
+          Scanner.AddDefine('UNIX');
+          end;
+        'SUNOS' :
+          begin
+          Scanner.AddDefine('SOLARIS');
+          Scanner.AddDefine('UNIX');
+          end;
+        'GO32V2' : Scanner.AddDefine('DPMI');
+        'BEOS' : Scanner.AddDefine('UNIX');
+        'QNX' : Scanner.AddDefine('UNIX');
+        'AROS' : Scanner.AddDefine('HASAMIGA');
+        'MORPHOS' : Scanner.AddDefine('HASAMIGA');
+        'AMIGA' : Scanner.AddDefine('HASAMIGA');
+      end;
+      // TargetCPU
+      s := UpperCase(CPUTarget);
+      Scanner.AddDefine('CPU'+s);
+      if (s='X86_64') then
+        Scanner.AddDefine('CPU64')
+      else
+        Scanner.AddDefine('CPU32');
+      end;
+    Parser := TPasParser.Create(Scanner, FileResolver, Engine);
+    if (poSkipDefaultDefs in Options) then
+      Parser.ImplicitUses.Clear;
+    Filename := '';
+    Parser.LogEvents:=Engine.ParserLogEvents;
+    Parser.OnLog:=Engine.Onlog;
+
+    For S in FPCCommandLine do
+      ProcessCmdLinePart(S);
+    if Filename = '' then
+      raise Exception.Create(SErrNoSourceGiven);
+{$IFDEF HASFS}
+    FileResolver.AddIncludePath(ExtractFilePath(FileName));
+{$ENDIF}
+    Scanner.OpenFile(Code.FileName);
+    Parser.ParseMain(Result);
+  finally
+    Parser.Free;
+    Scanner.Free;
+    FileResolver.Free;
+  end;
+end;
+
+{ TCodeToolsFileResolver }
+
+constructor TCodeToolsFileResolver.Create(aBuffer: TCodeBuffer);
+begin
+  Inherited Create;
+  FBuffer:=aBuffer;
+end;
+
+function TCodeToolsFileResolver.CreateLineReaderFromBuffer(aBuffer : TCodeBuffer) : TLineReader;
+
+Var
+  SLR : TStreamLineReader;
+
+begin
+  SLR:=TStreamLineReader.Create(aBuffer.FileName);
+  SLR.InitFromString(aBuffer.Source);
+  Result:=SLR;
+end;
+
+function TCodeToolsFileResolver.FindSourceFile(const AName: string
+  ): TLineReader;
+begin
+  if SameFileName(aName,FBuffer.Filename) then
+    Result:=CreateLineReaderFromBuffer(FBuffer)
+  else
+    Result:=inherited FindSourceFile(AName);
+end;
+
+
+end.
+

--- a/src/protocol/PasLS.Parser.pas
+++ b/src/protocol/PasLS.Parser.pas
@@ -155,6 +155,7 @@ begin
       Scanner.AddDefine(s);
       Case s of
         'LINUX' : Scanner.AddDefine('UNIX');
+        'DARWIN' : Scanner.AddDefine('UNIX');
         'FREEBSD' :
           begin
           Scanner.AddDefine('BSD');

--- a/src/protocol/lspprotocol.lpk
+++ b/src/protocol/lspprotocol.lpk
@@ -151,6 +151,10 @@
         <Filename Value="LSP.Messages.pas"/>
         <UnitName Value="LSP.Messages"/>
       </Item>
+      <Item>
+        <Filename Value="PasLS.Parser.pas"/>
+        <UnitName Value="PasLS.Parser"/>
+      </Item>
     </Files>
     <RequiredPkgs>
       <Item>

--- a/src/protocol/lspprotocol.pas
+++ b/src/protocol/lspprotocol.pas
@@ -16,7 +16,7 @@ uses
   LSP.Synchronization, LSP.Window, LSP.WorkDoneProgress, LSP.Workspace, 
   PasLS.CodeUtils, PasLS.Commands, PasLS.LazConfig, PasLS.TextLoop, 
   PasLS.SocketDispatcher, LSP.AllCommands, LSP.Streaming, LSP.BaseTypes, 
-  LSP.Messages, LazarusPackageIntf;
+  LSP.Messages, PasLS.Parser, LazarusPackageIntf;
 
 implementation
 


### PR DESCRIPTION
Hello Ryan,

This patch allows the fcl-passrc to be invoked on the current parse buffer, no need to save first.

I also removed the clearing of diagnostics on save notification.
It makes no sense to do so, since the result in VS-Code is that no diagnostics are shown.
(first you send diagnostics, immediatly after you clear them)

If you uncomment line 405 in LSP.Synchronization, then the diagnostic messages are updated as you type.

With this patch and the previous, the diagnostics work very well in VS code.
