### PR TITLE
* Code formatting

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,15 @@ The implementation is still incomplete.
    - executeCommand
 - diagnostics (incomplete)
 
+### Extra commands to be executed with **executeCommand**:
+
+* **pasls.completeCode** Complete code at cursor. Takes DocumentUri and
+  Position as options.
+* **pasls.formatCode** Format current file. Takes documentUri and Config file URI as options. 
+  The configuration file is the Jedi Code Formatter configuration file. You
+  can find an example in the Lazarus settings directory **~/.lazarus/jcfsettings.cfg**.
+  An extra example is included in this repository in **Sample-Formatting.cfg**
+
 ### Initialization Options
 
 Editors can supply [initialization options](https://microsoft.github.io/language-server-protocol/specifications/specification-3-15/#initialize) to the server, however each client handles this differently so please refer to your editors LSP plugin for more information.

--- a/Sample-Formatting.cfg
+++ b/Sample-Formatting.cfg
@@ -1,0 +1,184 @@
+<?xml version="1.0" ?>
+<JediCodeFormatSettings>
+    <WriteVersion> 2.44 </WriteVersion>
+    <WriteDateTime> 40208.0415705324 </WriteDateTime>
+    <Description> format settings for use with Lazarus </Description>
+  <Obfuscate>
+      <Enabled> False </Enabled>
+      <Caps> 1 </Caps>
+      <RemoveComments> True </RemoveComments>
+      <RemoveWhiteSpace> True </RemoveWhiteSpace>
+      <RemoveIndent> True </RemoveIndent>
+      <RebreakLines> True </RebreakLines>
+  </Obfuscate>
+  <Clarify>
+      <OnceOffs> 0 </OnceOffs>
+      <Warnings> True </Warnings>
+      <WarnUnusedParams> False </WarnUnusedParams>
+      <IgnoreUnusedParams> Sender </IgnoreUnusedParams>
+      <FileExtensions> dpr,lpr,pas,pp </FileExtensions>
+  </Clarify>
+  <Indent>
+      <IndentationSpaces> 2 </IndentationSpaces>
+      <FirstLevelIndent> 0 </FirstLevelIndent>
+      <HasFirstLevelIndent> False </HasFirstLevelIndent>
+      <IndentBeginEnd> False </IndentBeginEnd>
+      <IndentbeginEndSpaces> 2 </IndentbeginEndSpaces>
+      <IndentLibraryProcs> True </IndentLibraryProcs>
+      <IndentProcedureBody> False </IndentProcedureBody>
+      <KeepCommentsWithCodeInGlobals> True </KeepCommentsWithCodeInGlobals>
+      <KeepCommentsWithCodeInProcs> True </KeepCommentsWithCodeInProcs>
+      <KeepCommentsWithCodeInClassDef> True </KeepCommentsWithCodeInClassDef>
+      <KeepCommentsWithCodeElsewhere> True </KeepCommentsWithCodeElsewhere>
+      <IndentElse> False </IndentElse>
+      <IndentCaseElse> True </IndentCaseElse>
+      <IndentNestedTypes> False </IndentNestedTypes>
+      <IndentVarAndConstInClass> False </IndentVarAndConstInClass>
+  </Indent>
+  <Spaces>
+      <TabsToSpaces> True </TabsToSpaces>
+      <SpacesToTabs> False </SpacesToTabs>
+      <SpacesPerTab> 2 </SpacesPerTab>
+      <SpacesForTab> 2 </SpacesForTab>
+      <FixSpacing> True </FixSpacing>
+      <SpaceBeforeClassHeritage> False </SpaceBeforeClassHeritage>
+      <SpacesBeforeColonVar> 0 </SpacesBeforeColonVar>
+      <SpacesBeforeColonConst> 0 </SpacesBeforeColonConst>
+      <SpacesBeforeColonParam> 0 </SpacesBeforeColonParam>
+      <SpacesBeforeColonFn> 0 </SpacesBeforeColonFn>
+      <SpacesBeforeColonClassVar> 0 </SpacesBeforeColonClassVar>
+      <SpacesBeforeColonRecordField> 0 </SpacesBeforeColonRecordField>
+      <SpacesBeforeColonCaseLabel> 0 </SpacesBeforeColonCaseLabel>
+      <SpacesBeforeColonLabel> 0 </SpacesBeforeColonLabel>
+      <SpacesBeforeColonInGeneric> 0 </SpacesBeforeColonInGeneric>
+      <MaxSpacesInCode> 2 </MaxSpacesInCode>
+      <UseMaxSpacesInCode> True </UseMaxSpacesInCode>
+      <SpaceForOperator> 0 </SpaceForOperator>
+      <SpaceBeforeOpenBracketsInFunctionDeclaration> False </SpaceBeforeOpenBracketsInFunctionDeclaration>
+      <SpaceBeforeOpenBracketsInFunctionCall> False </SpaceBeforeOpenBracketsInFunctionCall>
+      <SpaceBeforeOpenSquareBracketsInExpression> False </SpaceBeforeOpenSquareBracketsInExpression>
+      <SpaceAfterOpenBrackets> False </SpaceAfterOpenBrackets>
+      <SpaceBeforeCloseBrackets> False </SpaceBeforeCloseBrackets>
+      <MoveSpaceToBeforeColon> False </MoveSpaceToBeforeColon>
+  </Spaces>
+  <Returns>
+      <WhenRebreakLines> 2 </WhenRebreakLines>
+      <MaxLineLength> 90 </MaxLineLength>
+      <NumReturnsAfterFinalEnd> 1 </NumReturnsAfterFinalEnd>
+      <RemoveBadReturns> True </RemoveBadReturns>
+      <AddGoodReturns> True </AddGoodReturns>
+      <UsesOnePerLine> False </UsesOnePerLine>
+      <BreakAfterUses> False </BreakAfterUses>
+      <RemoveExpressionReturns> True </RemoveExpressionReturns>
+      <RemoveVarReturns> True </RemoveVarReturns>
+      <NoReturnsInProperty> True </NoReturnsInProperty>
+      <RemoveProcedureDefReturns> True </RemoveProcedureDefReturns>
+      <RemoveReturns> True </RemoveReturns>
+      <RemoveVarBlankLines> True </RemoveVarBlankLines>
+      <RemoveProcHeaderBlankLines> True </RemoveProcHeaderBlankLines>
+      <Block> 1 </Block>
+      <BlockBegin> 0 </BlockBegin>
+      <Label> 1 </Label>
+      <LabelBegin> 1 </LabelBegin>
+      <CaseLabel> 1 </CaseLabel>
+      <CaseBegin> 1 </CaseBegin>
+      <CaseElse> 0 </CaseElse>
+      <CaseElseBegin> 0 </CaseElseBegin>
+      <EndElse> 0 </EndElse>
+      <ElseIf> 1 </ElseIf>
+      <ElseBegin> 0 </ElseBegin>
+      <BeforeCompilerDirectUses> 1 </BeforeCompilerDirectUses>
+      <BeforeCompilerDirectStatements> 0 </BeforeCompilerDirectStatements>
+      <BeforeCompilerDirectGeneral> 1 </BeforeCompilerDirectGeneral>
+      <AfterCompilerDirectUses> 1 </AfterCompilerDirectUses>
+      <AfterCompilerDirectStatements> 0 </AfterCompilerDirectStatements>
+      <AfterCompilerDirectGeneral> 1 </AfterCompilerDirectGeneral>
+      <ReturnChars> 0 </ReturnChars>
+      <RemoveConsecutiveBlankLines> True </RemoveConsecutiveBlankLines>
+      <MaxConsecutiveBlankLines> 4 </MaxConsecutiveBlankLines>
+      <MaxBlankLinesInSection> 1 </MaxBlankLinesInSection>
+      <LinesBeforeProcedure> 1 </LinesBeforeProcedure>
+  </Returns>
+  <Comments>
+      <RemoveEmptyDoubleSlashComments> True </RemoveEmptyDoubleSlashComments>
+      <RemoveEmptyCurlyBraceComments> True </RemoveEmptyCurlyBraceComments>
+  </Comments>
+  <Capitalisation>
+      <Enabled> True </Enabled>
+      <ReservedWords> 1 </ReservedWords>
+      <Operators> 1 </Operators>
+      <Directives> 1 </Directives>
+      <Constants> 1 </Constants>
+      <Types> 1 </Types>
+  </Capitalisation>
+  <SpecificWordCaps>
+      <Enabled> True </Enabled>
+      <Words>  </Words>
+  </SpecificWordCaps>
+  <Identifiers>
+      <Enabled> True </Enabled>
+      <Words> ActivePage,AnsiCompareStr,AnsiCompareText,AnsiUpperCase,AsBoolean,AsDateTime,AsFloat,AsInteger,Assign,AsString,AsVariant,BeginDrag,Buttons,Caption,Checked,Classes,ClassName,Clear,Close,Components,Controls,Count,Create,Data,Dec,Delete,Destroy,Dialogs,Enabled,EndDrag,EOF,Exception,Execute,False,FieldByName,First,Forms,Free,FreeAndNil,GetFirstChild,Graphics,Height,idAbort,idCancel,idIgnore,IDispatch,idNo,idOk,idRetry,idYes,Inc,Initialize,IntToStr,ItemIndex,IUnknown,Lines,Math,MaxValue,mbAbort,mbAll,mbCancel,mbHelp,mbIgnore,mbNo,mbOK,mbRetry,mbYes,mbYesToAll,Messages,MinValue,mnNoToAll,mrAbort,mrAll,mrCancel,mrIgnore,mrNo,mrNone,mrNoToAll,mrOk,mrRetry,mrYes,mrYesToAll,mtConfirmation,mtCustom,mtError,mtInformation,mtWarning,Name,Next,Open,Ord,ParamStr,PChar,Perform,ProcessMessages,Read,ReadOnly,RecordCount,Register,Release,Result,Sender,SetFocus,Show,ShowMessage,Source,StdCtrls,StrToInt,SysUtils,TAutoObject,TButton,TComponent,TDataModule,Text,TForm,TFrame,TList,TNotifyEvent,TObject,TObjectList,TPageControl,TPersistent,True,TStringList,TStrings,TTabSheet,Unassigned,Value,Visible,WideString,Width,Windows,Write </Words>
+  </Identifiers>
+  <NotIdent>
+      <Enabled> True </Enabled>
+      <Words> False,Name,nil,PChar,read,ReadOnly,True,WideString,write </Words>
+  </NotIdent>
+  <UnitNameCaps>
+      <Enabled> True </Enabled>
+      <Words> ActnColorMaps,ActnCtrls,ActnList,ActnMan,ActnMenus,ActnPopup,ActnRes,ADOConst,ADODB,ADOInt,AppEvnts,AxCtrls,BandActn,bdeconst,bdemts,Buttons,CheckLst,Classes,Clipbrd.pas,CmAdmCtl,ComCtrls,ComStrs,Consts,Controls,CtlConsts,CtlPanel,CustomizeDlg,DataBkr,DB,DBActns,dbcgrids,DBClient,DBClientActnRes,DBClientActns,DBCommon,DBConnAdmin,DBConsts,DBCtrls,DbExcept,DBGrids,DBLocal,DBLocalI,DBLogDlg,dblookup,DBOleCtl,DBPWDlg,DBTables,DBXpress,DdeMan,Dialogs,DrTable,DSIntf,ExtActns,ExtCtrls,ExtDlgs,FileCtrl,FMTBcd,Forms,Graphics,GraphUtil,Grids,HTTPIntr,IB,IBBlob,IBCustomDataSet,IBDatabase,IBDatabaseInfo,IBDCLConst,IBErrorCodes,IBEvents,IBExternals,IBExtract,IBGeneratorEditor,IBHeader,IBIntf,IBQuery,IBRestoreEditor,IBSecurityEditor,IBServiceEditor,IBSQL,IBSQLMonitor,IBStoredProc,IBTable,IBUpdateSQL,IBUtils,IBXConst,ImgList,Jcl8087,JclAbstractContainers,JclAlgorithms,JclAnsiStrings,JclAppInst,JclArrayLists,JclArraySets,JclBase,JclBinaryTrees,JclBorlandTools,JclCIL,JclCLR,JclCOM,JclComplex,JclCompression,JclConsole,JclContainerIntf,JclCounter,JclDateTime,JclDebug,JclDotNet,JclEDI,JclEDI_ANSIX12,JclEDI_ANSIX12_Ext,JclEDI_UNEDIFACT,JclEDI_UNEDIFACT_Ext,JclEDISEF,JclEDITranslators,JclEDIXML,JclExprEval,JclFileUtils,JclFont,JclGraphics,JclGraphUtils,JclHashMaps,JclHashSets,JclHookExcept,JclIniFiles,JclLANMan,JclLinkedLists,JclLocales,JclLogic,JclMapi,JclMath,JclMetadata,JclMIDI,JclMime,JclMiscel,JclMsdosSys,JclMultimedia,JclNTFS,JclPCRE,JclPeImage,JclPrint,JclQGraphics,JclQGraphUtils,JclQueues,JclRegistry,JclResources,JclRTTI,JclSchedule,JclSecurity,JclShell,JclSimpleXml,JclStacks,JclStatistics,JclStreams,JclStrHashMap,JclStringLists,JclStrings,JclStructStorage,JclSvcCtrl,JclSynch,JclSysInfo,JclSysUtils,JclTask,JclTD32,JclUnicode,JclUnitConv,JclUnitVersioning,JclUnitVersioningProviders,JclValidation,JclVectors,JclWideFormat,JclWideStrings,JclWin32,JclWin32Ex,JclWinMIDI,ListActns,Mask,MConnect,Menus,Midas,MidasCon,MidConst,MPlayer,MtsRdm,Mxconsts,ObjBrkr,OleAuto,OleConst,OleCtnrs,OleCtrls,OleDB,OleServer,Outline,Printers,Provider,recerror,ScktCnst,ScktComp,ScktMain,SConnect,ShadowWnd,SimpleDS,SMINTF,SqlConst,SqlExpr,SqlTimSt,StdActnMenus,StdActns,StdCtrls,StdStyleActnCtrls,SvcMgr,SysUtils,TabNotBk,Tabs,TConnect,Themes,ToolWin,ValEdit,VDBConsts,WinHelpViewer,XPActnCtrls,XPMan,XPStyleActnCtrls </Words>
+  </UnitNameCaps>
+  <Asm>
+      <Caps> 0 </Caps>
+      <BreaksAfterLabel> 1 </BreaksAfterLabel>
+      <BreaksAfterLabelEnabled> True </BreaksAfterLabelEnabled>
+      <StatementIndentEnabled> True </StatementIndentEnabled>
+      <StatementIndent> 7 </StatementIndent>
+      <ParamsIndentEnabled> True </ParamsIndentEnabled>
+      <ParamsIndent> 15 </ParamsIndent>
+  </Asm>
+  <PreProcessor>
+      <Enabled> True </Enabled>
+      <DefinedSymbols> MSWINDOWS </DefinedSymbols>
+      <DefinedOptions>  </DefinedOptions>
+  </PreProcessor>
+  <Align>
+      <AlignAssign> False </AlignAssign>
+      <AlignConst> False </AlignConst>
+      <AlignTypedef> False </AlignTypedef>
+      <AlignVars> False </AlignVars>
+      <AlignComment> False </AlignComment>
+      <AlignFields> False </AlignFields>
+      <InterfaceOnly> False </InterfaceOnly>
+      <MinColumn> 2 </MinColumn>
+      <MaxColumn> 60 </MaxColumn>
+      <MaxVariance> 5 </MaxVariance>
+      <MaxVarianceInterface> 5 </MaxVarianceInterface>
+      <MaxUnalignedStatements> 0 </MaxUnalignedStatements>
+  </Align>
+  <Replace>
+      <Enabled> False </Enabled>
+      <Words>  </Words>
+  </Replace>
+  <Uses>
+      <RemoveEnabled> False </RemoveEnabled>
+      <InsertInterfaceEnabled> False </InsertInterfaceEnabled>
+      <InsertImplementationEnabled> False </InsertImplementationEnabled>
+      <FindReplaceEnabled> False </FindReplaceEnabled>
+      <Remove>  </Remove>
+      <InsertInterface>  </InsertInterface>
+      <InsertImplementation>  </InsertImplementation>
+      <Find>  </Find>
+      <Replace>  </Replace>
+  </Uses>
+  <Transform>
+      <BeginEndStyle> 1 </BeginEndStyle>
+      <AddBlockEndSemicolon> True </AddBlockEndSemicolon>
+      <SortUsesInterface> False </SortUsesInterface>
+      <SortUsesImplmentation> False </SortUsesImplmentation>
+      <SortUsesProgram> False </SortUsesProgram>
+      <SortUsesBreakOnReturn> False </SortUsesBreakOnReturn>
+      <SortUsesBreakOnComment> False </SortUsesBreakOnComment>
+      <SortUsesSortOrder> 0 </SortUsesSortOrder>
+      <SortUsesNoComments> False </SortUsesNoComments>
+  </Transform>
+</JediCodeFormatSettings>

--- a/src/protocol/LSP.Capabilities.pas
+++ b/src/protocol/LSP.Capabilities.pas
@@ -339,7 +339,8 @@ begin
   referencesProvider := true;
   documentHighlightProvider := true;
   fexecuteCommandProvider := TExecuteCommandOptions.Create([
-    'pasls.completeCode'
+    'pasls.completeCode',
+    'pasls.formatCode'
   ]);
   // finlayHintProvider:= TInlayHintOptions.Create;
 

--- a/src/protocol/LSP.ExecuteCommand.pas
+++ b/src/protocol/LSP.ExecuteCommand.pas
@@ -79,7 +79,7 @@ end;
 
 function TExecuteCommandRequest.Process(var Params: TExecuteCommandParams): TLSPStreamable;
 var
-  documentURI: TDocumentUri;
+  documentURI,configURI: TDocumentUri;
   position: TPosition;
 begin with Params do
   begin
@@ -95,6 +95,12 @@ begin with Params do
           finally
             Position.Free;
           end;
+        end;
+      'pasls.formatCode':
+        begin
+          documentURI := arguments.Strings[0];
+          configURI := arguments.Strings[1];
+          PrettyPrint(Transport,documentURI,ConfigURI);
         end;
     end;
   end;

--- a/src/protocol/PasLS.Commands.pas
+++ b/src/protocol/PasLS.Commands.pas
@@ -35,6 +35,7 @@ procedure PrettyPrint(ATransport: TMessageTransport; DocumentURI: TDocumentUri; 
 implementation
 uses
   { CodeTools }
+  PasLS.Formatter,
   CodeToolManager, CodeCache,
   FindDeclarationTool,
   SourceChanger,
@@ -123,10 +124,22 @@ begin
     ATransport.SendDiagnostic( '🔴 CompleteCode Failed');
 end;
 
+
 procedure PrettyPrint(ATransport: TMessageTransport; DocumentURI: TDocumentUri; SettingsURI : TDocumentUri);
 
-begin
+var
+  Formatter : TFileFormatter;
+  FilePath,ConfPath : String;
 
+begin
+  FilePath := UriToPath(DocumentURI);
+  ConfPath := UriToPath(SettingsURI);
+  Formatter:=TFileFormatter.Create(aTransport);
+  try
+    Formatter.Process(FilePath,ConfPath);
+  finally
+    Formatter.Free;
+  end;
 end;
 
 end.

--- a/src/protocol/PasLS.Formatter.pas
+++ b/src/protocol/PasLS.Formatter.pas
@@ -1,0 +1,320 @@
+unit PasLS.Formatter;
+
+{$mode objfpc}{$H+}
+
+interface
+
+uses
+  { RTL/FCL }
+  Classes, SysUtils, SyncObjs,
+  { JCF }
+  ConvertTypes,FileConverter,
+  { LSP }
+  LSP.Messages;
+
+Type
+
+  { TFileFormatter }
+
+  TFileFormatter = Class
+  private
+    FConfigurationFile: String;
+    FConverter: TFileConverter;
+    FFileName: String;
+    FTransport: TMessageTransport;
+    FLock : TCriticalSection;
+    procedure DoMessage(const psUnit, psMessage: string;
+      const peMessageType: TStatusMessageType; const piY, piX: integer);
+  protected
+    Procedure Lock;
+    Procedure Unlock;
+    function CreateConverter : TFileConverter; virtual;
+    Property Converter : TFileConverter read FConverter;
+    procedure LoadConfiguration; virtual;
+    procedure DefaultConfiguration; virtual;
+    Procedure DoProcess; virtual;
+    // Only valid during process call
+    Property FileName : String Read FFileName;
+    Property ConfigurationFile : String Read FConfigurationFile;
+  Public
+    Constructor Create(aTransport : TMessageTransport);
+    Destructor Destroy; override;
+    Procedure Process(const aFileName : String; const aConfigurationFile : String);
+    Property Transport : TMessageTransport read FTransport;
+  end;
+
+implementation
+
+uses
+  SetTransform, SetReturns, SettingsTypes, JcfSettings;
+
+{ TFileFormatter }
+
+procedure TFileFormatter.DoMessage(const psUnit, psMessage: string;
+  const peMessageType: TStatusMessageType; const piY, piX: integer);
+
+var
+  S,Msg : String;
+
+begin
+  writestr(S,peMessageType);
+  Delete(S,1,2); // remove prefix.
+  Msg:=Format('[%s] %s(%d,%d): %s',[S,psUnit,piY-1,piX-1,psMessage]);
+  Transport.SendDiagnostic(Msg);
+end;
+
+procedure TFileFormatter.Lock;
+begin
+  FLock.Enter;
+end;
+
+procedure TFileFormatter.Unlock;
+begin
+  FLock.Leave;
+end;
+
+function TFileFormatter.CreateConverter: TFileConverter;
+begin
+  Result:=TFileConverter.Create;
+end;
+
+procedure TFileFormatter.LoadConfiguration;
+
+begin
+  FormatSettingsFromFile(FConfigurationFile);
+end;
+
+procedure TFileFormatter.DefaultConfiguration;
+
+Var
+  Cfg : TFormattingSettings; // shortcut.
+begin
+  Cfg:=FormattingSettings;
+  With Cfg.Obfuscate do
+    begin
+      Enabled:=False;
+    end;
+  with Cfg.Clarify do
+    begin
+      WarnUnusedParams:=False;
+      // Maybe overkill ?
+      IgnoreUnusedParams.Add('Sender');
+    end;
+  With Cfg.Indent do
+    begin
+      IndentSpaces:=2;
+      IndentBeginEnd:=True;
+      IndentBeginEndSpaces:=2;
+      IndentLibraryProcs:=True;
+      IndentProcedureBody:=False;
+      KeepCommentsWithCodeInGlobals:=True;
+      KeepCommentsWithCodeInProcs:=True;
+      KeepCommentsWithCodeInClassDef:=True;
+      KeepCommentsWithCodeElsewhere:=True;
+      IndentElse:=False;
+      IndentCaseElse:=True;
+      IndentNestedTypes:=False;
+      IndentVarAndConstInClass:=False;
+    end;
+  With Cfg.Spaces do
+    begin
+      TabsToSpaces:=True;
+      SpacesToTabs:=False;
+      SpacesPerTab:=2;
+      SpacesForTab:=2;
+      FixSpacing:=True;
+      SpaceBeforeClassHeritage:=False;
+      SpacesBeforeColonVar:=0;
+      SpacesBeforeColonConst:=0;
+      SpacesBeforeColonParam:=0;
+      SpacesBeforeColonFn:=0;
+      SpacesBeforeColonClassVar:=0;
+      SpacesBeforeColonRecordField:=0;
+      SpacesBeforeColonCaseLabel:=0;
+      SpacesBeforeColonLabel:=0;
+      SpacesBeforeColonInGeneric:=0;
+      MaxSpacesInCode:=2;
+      UseMaxSpacesInCode:=True;
+      SpaceForOperator:=eAlways;
+      SpaceBeforeOpenBracketsInFunctionDeclaration:=False;
+      SpaceBeforeOpenBracketsInFunctionCall:=False;
+      SpaceBeforeOpenSquareBracketsInExpression:=False;
+      SpaceAfterOpenBrackets:=False;
+      SpaceBeforeCloseBrackets:=False;
+      MoveSpaceToBeforeColon:=False;
+    end;
+  With Cfg.Returns do
+    begin
+      RebreakLines:=rbUsually;
+      MaxLineLength:=90;
+      NumReturnsAfterFinalEnd:=1;
+      RemoveBadReturns:=True;
+      AddGoodReturns:=True;
+      UsesClauseOnePerLine:=False;
+      BreakAfterUses:=False;
+      RemoveExpressionReturns:=True;
+      RemoveVarReturns:=True;
+      RemovePropertyReturns:=True;
+      RemoveProcedureDefReturns:=True;
+      RemoveBadReturns:=True;
+      RemoveVarBlankLines:=True;
+      RemoveProcHeaderBlankLines:=True;
+      BlockBeginStyle:=eLeave;
+      BlockStyle:=eAlways;
+      LabelStyle:=eLeave;
+      LabelBeginStyle:=eLeave;
+      CaseLabelStyle:=eLeave;
+      CaseBeginStyle:=eLeave;
+      CaseElseStyle:=eAlways;
+      CaseElseBeginStyle:=eAlways;
+      EndElseStyle:=eAlways;
+      ElseIfStyle:=eLeave;
+      ElseBeginStyle:=eAlways;
+      BeforeCompilerDirectUses:=eAlways;
+      BeforeCompilerDirectStatements:=eAlways;
+      BeforeCompilerDirectGeneral:=eLeave;
+      AfterCompilerDirectUses:=eLeave;
+      AfterCompilerDirectStatements:=eAlways;
+      AfterCompilerDirectGeneral:=eLeave;
+      ReturnChars:=rcLeaveAsIs;
+      RemoveConsecutiveBlankLines:=True;
+      MaxConsecutiveBlankLines:=4;
+      MaxBlankLinesInSection:=1;
+      LinesBeforeProcedure:=1;
+    end;
+  With Cfg.Caps do
+    begin
+      Enabled:=True;
+      ReservedWords:=ctLower;
+      Operators:=ctLower;
+      Directives:=ctUpper;
+      Constants:=ctLower;
+      Types:=ctLeaveAlone;
+    end;
+  With Cfg.SpecificWordCaps do
+    begin
+      Enabled:=False;
+    // Add here
+    // Words.Add('');
+    end;
+  with Cfg.IdentifierCaps do
+    begin
+      Enabled:=True;
+      Words.AddCommaText('ActivePage,AnsiCompareStr,AnsiCompareText,AnsiUpperCase,AsBoolean,AsDateTime,AsFloat,AsInteger,Assign,AsString,AsVariant,BeginDrag,Buttons,Caption,Checked,Classes,ClassName,Clear,Close,Components,Controls,Count,Create,Data,Dec,Delete,Destroy,Dialogs,Enabled,EndDrag,EOF,Exception,Execute,False,FieldByName,First,Forms,Free,FreeAndNil,GetFirstChild,Graphics,Height,idAbort,idCancel,idIgnore,IDispatch,idNo,idOk,idRetry,idYes,Inc,Initialize,IntToStr,ItemIndex,IUnknown,Lines,Math,MaxValue,mbAbort,mbAll,mbCancel,mbHelp,mbIgnore,mbNo,mbOK,mbRetry,mbYes,mbYesToAll,Messages,MinValue,mnNoToAll,mrAbort,mrAll,mrCancel,mrIgnore,mrNo,mrNone,mrNoToAll,mrOk,mrRetry,mrYes,mrYesToAll,mtConfirmation,mtCustom,mtError,mtInformation,mtWarning,Name,Next,Open,Ord,ParamStr,PChar,Perform,ProcessMessages,Read,ReadOnly,RecordCount,Register,Release,Result,Sender,SetFocus,Show,ShowMessage,Source,StdCtrls,StrToInt,SysUtils,TAutoObject,TButton,TComponent,TDataModule,Text,TForm,TFrame,TList,TNotifyEvent,TObject,TObjectList,TPageControl,TPersistent,True,TStringList,TStrings,TTabSheet,Unassigned,Value,Visible,WideString,Width,Windows,Write');
+    end;
+  with Cfg.NotIdentifierCaps do
+    begin
+      Enabled:=True;
+      Words.AddCommaText('False,Name,nil,PChar,read,ReadOnly,True,WideString,write');
+    end;
+  with Cfg.UnitNameCaps do
+    begin
+      Enabled:=True;
+      Words.AddCommaText('ActnColorMaps,ActnCtrls,ActnList,ActnMan,ActnMenus,ActnPopup,ActnRes,ADOConst,ADODB,ADOInt,AppEvnts,AxCtrls,BandActn,bdeconst,bdemts,Buttons,CheckLst,Classes,Clipbrd.pas,CmAdmCtl,ComCtrls,ComStrs,Consts,Controls,CtlConsts,CtlPanel,CustomizeDlg,DataBkr,DB,DBActns,dbcgrids,DBClient,DBClientActnRes,DBClientActns,DBCommon,DBConnAdmin,DBConsts,DBCtrls,DbExcept,DBGrids,DBLocal,DBLocalI,DBLogDlg,dblookup,DBOleCtl,DBPWDlg,DBTables,DBXpress,DdeMan,Dialogs,DrTable,DSIntf,ExtActns,ExtCtrls,ExtDlgs,FileCtrl,FMTBcd,Forms,Graphics,GraphUtil,Grids,HTTPIntr,IB,IBBlob,IBCustomDataSet,IBDatabase,IBDatabaseInfo,IBDCLConst,IBErrorCodes,IBEvents,IBExternals,IBExtract,IBGeneratorEditor,IBHeader,IBIntf,IBQuery,IBRestoreEditor,IBSecurityEditor,IBServiceEditor,IBSQL,IBSQLMonitor,IBStoredProc,IBTable,IBUpdateSQL,IBUtils,IBXConst,ImgList,Jcl8087,JclAbstractContainers,JclAlgorithms,JclAnsiStrings,JclAppInst,JclArrayLists,JclArraySets,JclBase,JclBinaryTrees,JclBorlandTools,JclCIL,JclCLR,JclCOM,JclComplex,JclCompression,JclConsole,JclContainerIntf,JclCounter,JclDateTime,JclDebug,JclDotNet,JclEDI,JclEDI_ANSIX12,JclEDI_ANSIX12_Ext,JclEDI_UNEDIFACT,JclEDI_UNEDIFACT_Ext,JclEDISEF,JclEDITranslators,JclEDIXML,JclExprEval,JclFileUtils,JclFont,JclGraphics,JclGraphUtils,JclHashMaps,JclHashSets,JclHookExcept,JclIniFiles,JclLANMan,JclLinkedLists,JclLocales,JclLogic,JclMapi,JclMath,JclMetadata,JclMIDI,JclMime,JclMiscel,JclMsdosSys,JclMultimedia,JclNTFS,JclPCRE,JclPeImage,JclPrint,JclQGraphics,JclQGraphUtils,JclQueues,JclRegistry,JclResources,JclRTTI,JclSchedule,JclSecurity,JclShell,JclSimpleXml,JclStacks,JclStatistics,JclStreams,JclStrHashMap,JclStringLists,JclStrings,JclStructStorage,JclSvcCtrl,JclSynch,JclSysInfo,JclSysUtils,JclTask,JclTD32,JclUnicode,JclUnitConv,JclUnitVersioning,JclUnitVersioningProviders,JclValidation,JclVectors,JclWideFormat,JclWideStrings,JclWin32,JclWin32Ex,JclWinMIDI,ListActns,Mask,MConnect,Menus,Midas,MidasCon,MidConst,MPlayer,MtsRdm,Mxconsts,ObjBrkr,OleAuto,OleConst,OleCtnrs,OleCtrls,OleDB,OleServer,Outline,Printers,Provider,recerror,ScktCnst,ScktComp,ScktMain,SConnect,ShadowWnd,SimpleDS,SMINTF,SqlConst,SqlExpr,SqlTimSt,StdActnMenus,StdActns,StdCtrls,StdStyleActnCtrls,SvcMgr,SysUtils,TabNotBk,Tabs,TConnect,Themes,ToolWin,ValEdit,VDBConsts,WinHelpViewer,XPActnCtrls,XPMan,XPStyleActnCtrls');
+    end;
+  with Cfg.SetAsm do
+    begin
+      Capitalisation:=ctUpper;
+      BreaksAfterLabel:=1;
+      BreaksAfterLabelEnabled:=True;
+      StatementIndentEnabled:=True;
+      StatementIndent:=7;
+      ParamsIndentEnabled:=True;
+      ParamsIndent:=15;
+    end;
+  With Cfg.PreProcessor do
+    begin
+    Enabled:=False;
+    // DefinedSymbols.Add('');
+    // DefinedOptions.Add('');
+    end;
+  With Cfg.Align do
+    begin
+      AlignAssign:=False;
+      AlignConst:=False;
+      AlignTypedef:=False;
+      AlignVar:=False;
+      AlignComment:=False;
+      AlignField:=False;
+      InterfaceOnly:=False;
+      MinColumn:=2;
+      MaxColumn:=60;
+      MaxVariance:=5;
+      MaxVarianceInterface:=5;
+      MaxUnalignedStatements:=0;
+    end;
+  With Cfg.Replace do
+    begin
+    Enabled:=False;
+    end;
+  With Cfg.UsesClause do
+    begin
+    RemoveEnabled:=False ;
+    InsertInterfaceEnabled:=False ;
+    InsertImplementationEnabled:=False;
+    FindReplaceEnabled:=False;
+    // Remove.Add('');
+    // InsertInterface.Add('');
+    // InsertImplementation.Add('')
+    // Find.Add('');
+    // Replace.Add('')
+    end;
+  With Cfg.Transform do
+    begin
+    BeginEndStyle:= eLeave ;
+    AddBlockEndSemicolon:= True ;
+    SortInterfaceUses:=False;
+    SortImplementationUses:=False;
+    SortProgramUses:=False;
+    BreakUsesSortOnComment:=False;
+    BreakUsesSortOnReturn:=False;
+    UsesSortOrder:=eAlpha;
+    SortUsesNoComments:= False ;
+    end;
+end;
+
+procedure TFileFormatter.DoProcess;
+begin
+  if (ConfigurationFile<>'') then
+    LoadConfiguration
+  else
+    DefaultConfiguration;
+
+  FConverter.ProcessFile(FileName);
+end;
+
+constructor TFileFormatter.Create(aTransport: TMessageTransport);
+begin
+  FTransport:=aTransport;
+  FLock:=TCriticalSection.Create;
+  FConverter:=CreateConverter;
+  FConverter.GuiMessages:=False;
+  FConverter.YesAll:=True;
+  FConverter.OnStatusMessage:=@DoMessage;
+end;
+
+destructor TFileFormatter.Destroy;
+begin
+  FreeAndNil(FLock);
+  FreeAndNil(FConverter);
+  inherited Destroy;
+end;
+
+procedure TFileFormatter.Process(const aFileName: String;
+  const aConfigurationFile: String);
+begin
+  FFileName:=aFileName;
+  FConfigurationFile:=aConfigurationFile;
+  Lock;
+  try
+    DoProcess;
+  finally
+    UnLock;
+    FFileName:='';
+    FConfigurationFile:='';
+  end;
+
+end;
+
+end.
+

--- a/src/protocol/PasLS.Parser.pas
+++ b/src/protocol/PasLS.Parser.pas
@@ -17,7 +17,7 @@ Type
   Protected
     function CreateLineReaderFromBuffer(aBuffer: TCodeBuffer): TLineReader;
   Public
-    Constructor Create(aBuffer : TCodeBuffer);
+    Constructor Create(aBuffer : TCodeBuffer); reintroduce;
     function FindSourceFile(const AName: string): TLineReader; override;
     Property Buffer : TCodeBuffer read FBuffer;
   end;

--- a/src/protocol/lspprotocol.lpk
+++ b/src/protocol/lspprotocol.lpk
@@ -155,8 +155,15 @@
         <Filename Value="PasLS.Parser.pas"/>
         <UnitName Value="PasLS.Parser"/>
       </Item>
+      <Item>
+        <Filename Value="PasLS.Formatter.pas"/>
+        <UnitName Value="PasLS.Formatter"/>
+      </Item>
     </Files>
     <RequiredPkgs>
+      <Item>
+        <PackageName Value="jcfnogui"/>
+      </Item>
       <Item>
         <PackageName Value="CodeTools"/>
       </Item>

--- a/src/protocol/lspprotocol.pas
+++ b/src/protocol/lspprotocol.pas
@@ -16,7 +16,7 @@ uses
   LSP.Synchronization, LSP.Window, LSP.WorkDoneProgress, LSP.Workspace, 
   PasLS.CodeUtils, PasLS.Commands, PasLS.LazConfig, PasLS.TextLoop, 
   PasLS.SocketDispatcher, LSP.AllCommands, LSP.Streaming, LSP.BaseTypes, 
-  LSP.Messages, PasLS.Parser, LazarusPackageIntf;
+  LSP.Messages, PasLS.Parser, PasLS.Formatter, LazarusPackageIntf;
 
 implementation
 


### PR DESCRIPTION
Ryan,

This implements a formatting command pasls.formatCode. 
It requires the file to be saved before you can call it.

I added a sample configuration file.

if you wish to compile with a Makefile, you must add the directories below the lazarus components/jcf2 directory to the unit search path and the include file path.

The lazarus package jcfnogui has been submitted to the Lazarus team.