### PR TITLE
Multi diagnostic

### DIFF
--- a/src/protocol/LSP.Completion.pas
+++ b/src/protocol/LSP.Completion.pas
@@ -639,7 +639,7 @@ begin with Params do
                 end;
             end;
         end else begin
-          PublishDiagnostic(Self.Transport,'');
+          DiagnosticsHandler.PublishDiagnostic(Self.Transport,'');
           Result.isIncomplete := true;
         end;
     except

--- a/src/protocol/LSP.Completion.pas
+++ b/src/protocol/LSP.Completion.pas
@@ -639,7 +639,7 @@ begin with Params do
                 end;
             end;
         end else begin
-          DiagnosticsHandler.PublishDiagnostic(Self.Transport,'');
+          PublishCodeToolsError(Self.Transport,'');
           Result.isIncomplete := true;
         end;
     except

--- a/src/protocol/LSP.Diagnostics.pas
+++ b/src/protocol/LSP.Diagnostics.pas
@@ -25,7 +25,7 @@ interface
 
 uses
   { RTL }
-  Classes, 
+  Classes, Types,
   { Code Tools }
   CodeToolManager, CodeCache,
   { Protocol }
@@ -211,19 +211,35 @@ function StrictSyntaxCheck(aTransport : TMessageTransport; Code: TCodeBuffer) : 
 
 Var
   Module : TPasModule;
+  SourceParser : TSourceParser;
+  Args : TStringDynArray;
+  I : Integer;
 
 begin
+  Args:=[];
   Result:=False;
   Module:=nil;
+  SourceParser:=Nil;
   try
     try
-      Module:=ParseSource([Code.Filename],Code,EnvironmentSettings.fpcTarget,EnvironmentSettings.fpcTargetCPU,[]);
+      SourceParser:=TSourceParser.Create;
+      SourceParser.Code:=Code;
+      SourceParser.OSTarget:=EnvironmentSettings.fpcTarget;
+      SourceParser.CPUTarget:=EnvironmentSettings.fpcTargetCPU;
+      SourceParser.Options:=[];
+      SetLength(Args,ServerSettings.fpcOptions.Count+1);
+      for I:=0 to ServerSettings.fpcOptions.Count-1 do
+        Args[i]:=ServerSettings.fpcOptions[i];
+      Args[Length(Args)-1]:=Code.Filename;
+      SourceParser.CommandLine:=Args;
+      Module:=SourceParser.ParseSource;
       Result:=True;
     except
       on e : exception do
         SendError(E);
     end;
   finally
+    SourceParser.Free;
     Module.Free;
   end;
 end;

--- a/src/protocol/LSP.Diagnostics.pas
+++ b/src/protocol/LSP.Diagnostics.pas
@@ -93,10 +93,11 @@ type
     function CodeToolsCheckSyntax(aDiagnostics: TPublishDiagnostics; aTransport: TMessageTransport; Code: TCodeBuffer): boolean;
   Public
     procedure CheckSyntax(aTransport : TMessageTransport; Code: TCodeBuffer);
-    procedure PublishDiagnostic(aTransport : TMessageTransport; UserMessage: String = '');
+    procedure SendDiagnosticMessage(aTransport : TMessageTransport; UserMessage: String = '');
   end;
 
 Function DiagnosticsHandler : TDiagnosticsHandler;
+procedure PublishCodeToolsError(aTransport : TMessageTransport; const aMessage : string);
 
 implementation
 
@@ -114,6 +115,12 @@ begin
   if _DiagnosticsHandler=Nil then
     _DiagnosticsHandler:=TDiagnosticsHandler.Create;
   Result:=_DiagnosticsHandler;
+end;
+
+procedure PublishCodeToolsError(aTransport: TMessageTransport;
+  const aMessage: string);
+begin
+  DiagnosticsHandler.SendDiagnosticMessage(aTransport,aMessage);
 end;
 
 Procedure TDiagnosticsHandler.AddUserDiagnostic(Diagnostics : TPublishDiagnostics; aTransport: TMessageTransport; UserMessage : String);
@@ -189,7 +196,7 @@ end;
 
 { Publish the last code tools error as a diagnostics }
 
-procedure TDiagnosticsHandler.PublishDiagnostic(aTransport : TMessageTransport; UserMessage: String = '');
+procedure TDiagnosticsHandler.SendDiagnosticMessage(aTransport : TMessageTransport; UserMessage: String = '');
 var
   Notification: TPublishDiagnostics;
 

--- a/src/protocol/LSP.GotoDeclaration.pas
+++ b/src/protocol/LSP.GotoDeclaration.pas
@@ -61,7 +61,7 @@ begin with Params do
     else
       begin
         Result := nil;
-        DiagnosticsHandler.PublishDiagnostic(Transport,'');
+        PublishCodeToolsError(Transport,'');
       end;
   end;
 end;

--- a/src/protocol/LSP.GotoDeclaration.pas
+++ b/src/protocol/LSP.GotoDeclaration.pas
@@ -61,7 +61,7 @@ begin with Params do
     else
       begin
         Result := nil;
-        PublishDiagnostic(Transport,'');
+        DiagnosticsHandler.PublishDiagnostic(Transport,'');
       end;
   end;
 end;

--- a/src/protocol/LSP.GotoDefinition.pas
+++ b/src/protocol/LSP.GotoDefinition.pas
@@ -79,7 +79,7 @@ begin with Params do
     else
       begin
         Result := nil;
-        PublishDiagnostic(Transport);
+        DiagnosticsHandler.PublishDiagnostic(Transport);
       end;
   end;
 end;

--- a/src/protocol/LSP.GotoDefinition.pas
+++ b/src/protocol/LSP.GotoDefinition.pas
@@ -79,7 +79,7 @@ begin with Params do
     else
       begin
         Result := nil;
-        DiagnosticsHandler.PublishDiagnostic(Transport);
+        PublishCodeToolsError(Transport,'');
       end;
   end;
 end;

--- a/src/protocol/LSP.GotoImplementation.pas
+++ b/src/protocol/LSP.GotoImplementation.pas
@@ -63,7 +63,7 @@ begin with Params do
       end
     else
       begin
-        PublishDiagnostic(Transport);
+        DiagnosticsHandler.PublishDiagnostic(Transport);
         Result := nil;
       end;
   end;

--- a/src/protocol/LSP.GotoImplementation.pas
+++ b/src/protocol/LSP.GotoImplementation.pas
@@ -63,7 +63,7 @@ begin with Params do
       end
     else
       begin
-        DiagnosticsHandler.PublishDiagnostic(Transport);
+        PublishCodeToolsError(Transport,'');
         Result := nil;
       end;
   end;

--- a/src/protocol/LSP.References.pas
+++ b/src/protocol/LSP.References.pas
@@ -132,7 +132,7 @@ begin
     X,Y,
     DeclCode,DeclX,DeclY,DeclTopLine) then
   begin
-    PublishDiagnostic(Transport,'FindMainDeclaration failed in '+StartSrcCode.FileName+' at '+IntToStr(Y)+':'+IntToStr(X));
+    DiagnosticsHandler.PublishDiagnostic(Transport,'FindMainDeclaration failed in '+StartSrcCode.FileName+' at '+IntToStr(Y)+':'+IntToStr(X));
     ExitCode:=-1;
     exit;
   end;
@@ -181,7 +181,7 @@ begin
         DeclCode,DeclX,DeclY,
         Code, true, ListOfPCodeXYPosition, Cache) then
       begin
-        PublishDiagnostic(Transport,'FindReferences failed in "'+Code.Filename+'"');
+        DiagnosticsHandler.PublishDiagnostic(Transport,'FindReferences failed in "'+Code.Filename+'"');
         continue;
       end;
       if ListOfPCodeXYPosition=nil then continue;

--- a/src/protocol/LSP.References.pas
+++ b/src/protocol/LSP.References.pas
@@ -132,7 +132,7 @@ begin
     X,Y,
     DeclCode,DeclX,DeclY,DeclTopLine) then
   begin
-    DiagnosticsHandler.PublishDiagnostic(Transport,'FindMainDeclaration failed in '+StartSrcCode.FileName+' at '+IntToStr(Y)+':'+IntToStr(X));
+    PublishCodeToolsError(Transport,'FindMainDeclaration failed in '+StartSrcCode.FileName+' at '+IntToStr(Y)+':'+IntToStr(X));
     ExitCode:=-1;
     exit;
   end;
@@ -181,7 +181,7 @@ begin
         DeclCode,DeclX,DeclY,
         Code, true, ListOfPCodeXYPosition, Cache) then
       begin
-        DiagnosticsHandler.PublishDiagnostic(Transport,'FindReferences failed in "'+Code.Filename+'"');
+        PublishCodeToolsError(Transport,'FindReferences failed in "'+Code.Filename+'"');
         continue;
       end;
       if ListOfPCodeXYPosition=nil then continue;

--- a/src/protocol/LSP.SignatureHelp.pas
+++ b/src/protocol/LSP.SignatureHelp.pas
@@ -320,7 +320,7 @@ begin
     try
       if not CodeToolBoss.FindCodeContext(Code, X + 1, Y + 1, CodeContext) or (CodeContext = nil) or (CodeContext.Count = 0) then
         begin
-          DiagnosticsHandler.PublishDiagnostic(Transport);
+          PublishCodeToolsError(Transport,'');
           exit(nil);
         end;
 

--- a/src/protocol/LSP.SignatureHelp.pas
+++ b/src/protocol/LSP.SignatureHelp.pas
@@ -320,7 +320,7 @@ begin
     try
       if not CodeToolBoss.FindCodeContext(Code, X + 1, Y + 1, CodeContext) or (CodeContext = nil) or (CodeContext.Count = 0) then
         begin
-          PublishDiagnostic(Transport);
+          DiagnosticsHandler.PublishDiagnostic(Transport);
           exit(nil);
         end;
 

--- a/src/protocol/LSP.Synchronization.pas
+++ b/src/protocol/LSP.Synchronization.pas
@@ -242,7 +242,7 @@ begin with Params do
     if Code = nil then
       Code := CodeToolBoss.LoadFile(Path, False, False);
       
-    CheckSyntax(Transport,Code);
+    DiagnosticsHandler.CheckSyntax(Transport,Code);
 
     //if SymbolManager <> nil then
     //  SymbolManager.FileModified(Code);
@@ -294,7 +294,7 @@ begin with Params do
     Code := CodeToolBoss.FindFile(Params.textDocument.LocalPath);
     if SymbolManager <> nil then
       SymbolManager.FileModified(Code);
-    CheckSyntax(Transport,Code);
+    DiagnosticsHandler.CheckSyntax(Transport,Code);
     // ClearDiagnostics(Transport,Code);
   end;
 end;

--- a/src/protocol/PasLS.Parser.pas
+++ b/src/protocol/PasLS.Parser.pas
@@ -22,7 +22,7 @@ Type
   Protected
     function CreateLineReaderFromBuffer(aBuffer: TCodeBuffer): TLineReader;
   Public
-    Constructor Create(aBuffer : TCodeBuffer);
+    Constructor Create(aBuffer : TCodeBuffer); reintroduce;
     function FindSourceFile(const AName: string): TLineReader; override;
     Property Buffer : TCodeBuffer read FBuffer;
   end;
@@ -258,8 +258,10 @@ begin
           With FParser.CurSourcePos do
              begin
              aCode:=-1;
+             {$IFDEF MULTIERROR}
              if E is EParserError then
                aCode:=EParserError(E).ErrNo;
+             {$ENDIF}
              FOnError(Self,E.Message,FileName,aCode,Row,Column);
              end;
         end;

--- a/src/protocol/PasLS.Parser.pas
+++ b/src/protocol/PasLS.Parser.pas
@@ -5,7 +5,7 @@ unit PasLS.Parser;
 interface
 
 uses
-  Classes, SysUtils, PParser, PScanner, PasTree, CodeCache;
+  Classes, SysUtils, PParser, PScanner, PasTree, CodeCache, Types;
 
 Type
 
@@ -33,11 +33,23 @@ Type
     function FindElement(const AName: String): TPasElement; override;
   end;
 
-function ParseSource(const FPCCommandLine : Array of String;
-                     const Code : TCodeBuffer;
-                     OSTarget, CPUTarget: String;
-                     Options : TParseSourceOptions): TPasModule;
+  { TSourceParser }
 
+  TSourceParser = Class(TObject)
+  private
+    FCode: TCodeBuffer;
+    FCommandLine: TStringDynArray;
+    FCPUTarget: String;
+    FOptions: TParseSourceOptions;
+    FOSTarget: String;
+  Public
+    function ParseSource: TPasModule;
+    Property CommandLine : TStringDynArray Read FCommandLine Write FCommandLine;
+    Property Code : TCodeBuffer Read FCode Write FCode;
+    Property OSTarget : String Read FOSTarget Write FOSTarget;
+    Property CPUTarget : String Read FCPUTarget Write FCPUTarget;
+    Property Options : TParseSourceOptions Read FOptions Write FOptions;
+  end;
 
 implementation
 
@@ -64,11 +76,9 @@ begin
   Result := nil;
 end;
 
+{ TSourceParser }
 
-function ParseSource(const FPCCommandLine : Array of String;
-                     const Code : TCodeBuffer;
-                     OSTarget, CPUTarget: String;
-                     Options : TParseSourceOptions): TPasModule;
+function TSourceParser.ParseSource: TPasModule;
 
 var
   FileResolver: TBaseFileResolver;
@@ -197,7 +207,7 @@ begin
     Parser.LogEvents:=Engine.ParserLogEvents;
     Parser.OnLog:=Engine.Onlog;
 
-    For S in FPCCommandLine do
+    For S in CommandLine do
       ProcessCmdLinePart(S);
     if Filename = '' then
       raise Exception.Create(SErrNoSourceGiven);

--- a/src/protocol/PasLS.Parser.pas
+++ b/src/protocol/PasLS.Parser.pas
@@ -7,6 +7,11 @@ interface
 uses
   Classes, SysUtils, PParser, PScanner, PasTree, CodeCache, Types;
 
+// Detect presence of OnError etc.
+{$IF Declared(TPasParserErrorHandler)}
+{$DEFINE MULTIERROR}
+{$ENDIF}
+
 Type
 
  { TCodeToolsFileResolver }
@@ -34,21 +39,28 @@ Type
   end;
 
   { TSourceParser }
-
+  TReportParserErrorEvent = Procedure (Sender : TObject; Const aError, aFileName : string; aCode, aLine, aCol : Integer) Of Object;
   TSourceParser = Class(TObject)
   private
+    FOnError: TReportParserErrorEvent;
+    FParser: TPasParser;
     FCode: TCodeBuffer;
     FCommandLine: TStringDynArray;
     FCPUTarget: String;
     FOptions: TParseSourceOptions;
     FOSTarget: String;
+{$IFDEF MULTIERROR}
+    procedure DoError(Sender: TObject; const aContext: TRecoveryContext;
+      var aAllowRecovery: Boolean);
+{$ENDIF}
   Public
-    function ParseSource: TPasModule;
+    Function ParseSource: TPasModule;
     Property CommandLine : TStringDynArray Read FCommandLine Write FCommandLine;
     Property Code : TCodeBuffer Read FCode Write FCode;
     Property OSTarget : String Read FOSTarget Write FOSTarget;
     Property CPUTarget : String Read FCPUTarget Write FCPUTarget;
     Property Options : TParseSourceOptions Read FOptions Write FOptions;
+    Property OnError : TReportParserErrorEvent Read FOnError Write FOnError;
   end;
 
 implementation
@@ -78,11 +90,30 @@ end;
 
 { TSourceParser }
 
+{$IFDEF MULTIERROR}
+procedure TSourceParser.DoError(Sender: TObject;
+  const aContext: TRecoveryContext; var aAllowRecovery: Boolean);
+
+var
+  aCode : Integer;
+
+begin
+  aAllowRecovery:=True;
+  If Assigned(FOnError) then
+    begin
+    if aContext.Error is EParserError then
+      aCode:=EParserError(aContext.Error).ErrNo
+    else
+      aCode:=-1;
+    With FParser.CurSourcePos do
+      FOnError(Self,aContext.Error.Message,FileName,aCode, Row,Column);
+    end;
+end;
+{$ENDIF}
 function TSourceParser.ParseSource: TPasModule;
 
 var
   FileResolver: TBaseFileResolver;
-  Parser: TPasParser;
   Filename: String;
   Scanner: TPascalScanner;
 
@@ -137,6 +168,7 @@ var
 var
   S: String;
   Engine : TSimpleEngine;
+  aCode : integer;
 
 begin
   if DefaultFileResolverClass=Nil then
@@ -144,7 +176,7 @@ begin
   Result := nil;
   FileResolver := nil;
   Scanner := nil;
-  Parser := nil;
+  FParser := nil;
   Engine:=Nil;
   try
     Engine:=TSimpleEngine.Create;
@@ -200,24 +232,40 @@ begin
       else
         Scanner.AddDefine('CPU32');
       end;
-    Parser := TPasParser.Create(Scanner, FileResolver, Engine);
+    FParser := TPasParser.Create(Scanner, FileResolver, Engine);
     if (poSkipDefaultDefs in Options) then
-      Parser.ImplicitUses.Clear;
+      FParser.ImplicitUses.Clear;
     Filename := '';
-    Parser.LogEvents:=Engine.ParserLogEvents;
-    Parser.OnLog:=Engine.Onlog;
-
+    FParser.LogEvents:=Engine.ParserLogEvents;
+    FParser.OnLog:=Engine.Onlog;
+{$IFDEF MULTIERROR}
+    FParser.MaxErrorCount:=50;
+    FParser.OnError:=@DoError;
+{$ENDIF}
     For S in CommandLine do
       ProcessCmdLinePart(S);
     if Filename = '' then
       raise Exception.Create(SErrNoSourceGiven);
-{$IFDEF HASFS}
     FileResolver.AddIncludePath(ExtractFilePath(FileName));
-{$ENDIF}
     Scanner.OpenFile(Code.FileName);
-    Parser.ParseMain(Result);
+    try
+      FParser.ParseMain(Result);
+    except
+      on E : Exception do
+        begin
+        FreeAndNil(Result);
+        if Assigned(FOnError) then
+          With FParser.CurSourcePos do
+             begin
+             aCode:=-1;
+             if E is EParserError then
+               aCode:=EParserError(E).ErrNo;
+             FOnError(Self,E.Message,FileName,aCode,Row,Column);
+             end;
+        end;
+    end;
   finally
-    Parser.Free;
+    FreeAndNil(FParser);
     Scanner.Free;
     FileResolver.Free;
   end;

--- a/src/protocol/lspprotocol.lpk
+++ b/src/protocol/lspprotocol.lpk
@@ -14,7 +14,6 @@
         <CompilerMessages>
           <IgnoredMessages idx6058="True" idx5024="True" idx3124="True" idx3123="True"/>
         </CompilerMessages>
-        <CustomOptions Value="-dMULTIERROR"/>
         <OtherDefines Count="1">
           <Define0 Value="MULTIERROR"/>
         </OtherDefines>

--- a/src/protocol/lspprotocol.lpk
+++ b/src/protocol/lspprotocol.lpk
@@ -7,12 +7,17 @@
     <CompilerOptions>
       <Version Value="11"/>
       <SearchPaths>
+        <OtherUnitFiles Value="passrc"/>
         <UnitOutputDirectory Value="lib/$(TargetCPU)-$(TargetOS)"/>
       </SearchPaths>
       <Other>
         <CompilerMessages>
           <IgnoredMessages idx6058="True" idx5024="True" idx3124="True" idx3123="True"/>
         </CompilerMessages>
+        <CustomOptions Value="-dMULTIERROR"/>
+        <OtherDefines Count="1">
+          <Define0 Value="MULTIERROR"/>
+        </OtherDefines>
       </Other>
     </CompilerOptions>
     <Description Value="Object Pascal - Language Server Protocol implementation"/>


### PR DESCRIPTION
Ryan,

This rework allows to report more than one diagnostic when checking syntax errors.
It automatically detects whether you're compiling with support for multiple errors in fcl-passrc
(as it exists now in FPC trunk)

I can successfully see more than one diagnostic error now. It also displays the error codes as defined in fcl-passrc
(they should match the ones in FPC)