### PR TITLE
Compilation fixes and instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,12 +158,33 @@ https://github.com/genericptr/pasls-vscode) and configure the settings according
 
 ## Building
 
-Requires Free Pascal Compiler version 3.2.0 and Lazarus version 2.0.8,
-open the project file in Lazarus or use the commandline:
+Requires Free Pascal Compiler version 3.2.0 and Lazarus trunk sources.
+
+To build using Lazarus, you need to follow the following steps:
+
+* Update or download the sources from gitlab:
+[https://gitlab.com/freepascal.org/lazarus/lazarus](https://gitlab.com/freepascal.org/lazarus/lazarus)
+
+* Open the jcfbase package in the lazarus IDE. It is located in the
+  `components/jcf2` directory.  You can compile this package in the IDE.
+  
+  You need to do this only once, so Lazarus knows about the jcfbase package.
+  (unless you wish to update the Jedi Code Formatter)
+
+* open the `lspprotocol.lpk` package in Lazarus. It is located in the
+  [src/protocol](src/protocol) directory.
+  You can compile this package in the IDE, but this is not needed: The
+Lazarus IDE and Lazbuild simply need to know where itis.
+
+* open the `src/standard/pasls.lpi` project file in Lazarus, and compile the
+  program. or use the lazbuid commandline:
 
 ```sh
 lazbuild src/standard/pasls.lpi
 ```
+The `lspprotocol.lpk` package and `pasls.lpi` are both in the
+`pascallanguageserver.lpg`project group; if you have project group support enabled,
+then you can use this to compile this package and the executable.
 
 ## Debugging the LSP server
 

--- a/src/protocol/PasLS.ApplyEdit.pas
+++ b/src/protocol/PasLS.ApplyEdit.pas
@@ -1,0 +1,62 @@
+unit PasLS.ApplyEdit;
+
+{$mode objfpc}{$H+}
+
+interface
+
+uses
+  { RTL }
+  Classes, SysUtils,
+  { LSP }
+  LSP.Messages, LSP.Basic, LSP.Base;
+
+procedure DoApplyEdit(aTransport: TMessageTransport; DocumentURI, Text: String; Range: TRange);
+
+implementation
+
+Uses
+  { LSP }
+  PasLS.Settings,
+  LSP.BaseTypes,
+  LSP.WorkSpace;
+
+procedure DoApplyEdit(aTransport: TMessageTransport; DocumentURI, Text: String; Range: TRange);
+var
+  Params: TApplyWorkspaceEditParams;
+  Edit: TWorkspaceEdit;
+  TextEdit: TTextEdit;
+  Msg: TWorkspaceApplyEditRequest;
+  TextDocumentEdit: TTextDocumentEdit;
+begin
+  Msg := nil;
+  Params := TApplyWorkspaceEditParams.Create;
+  try
+    Edit := Params.edit;
+
+    TextDocumentEdit := Edit.documentChanges.Add;
+    TextDocumentEdit.textDocument.uri := DocumentURI;
+
+    // TODO: we're hacking around clients by using the versioning system they allow
+    // but ideally you're supposed to provided correct versions.
+    // See `OptionalVersionedTextDocumentIdentifier` from
+    // https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#versionedTextDocumentIdentifier
+    if ClientInfo.name = TClients.SublimeTextLSP then
+      TextDocumentEdit.textDocument.version := nil
+    else
+      TextDocumentEdit.textDocument.version := 0;
+
+    TextEdit := TextDocumentEdit.edits.Add;
+    TextEdit.range := range;
+    TextEdit.newText := Text;
+
+    Msg := TWorkspaceApplyEditRequest.Create(aTransport);
+    Msg.Execute(params, 'workspace/applyEdit');  // TODO: the class should know it's method name
+  finally
+    Params.Free;
+    Msg.Free;
+  end;
+end;
+
+
+end.
+

--- a/src/protocol/PasLS.RemoveEmptyMethods.pas
+++ b/src/protocol/PasLS.RemoveEmptyMethods.pas
@@ -1,0 +1,101 @@
+unit PasLS.RemoveEmptyMethods;
+
+{$mode objfpc}{$H+}
+
+interface
+
+uses
+  { RTL }
+  Classes, SysUtils,
+  { Codetools }
+  CodeToolManager, CodeCache,
+  { LSP }
+  LSP.Messages, LSP.Basic, LSP.Base;
+
+Type
+
+  { TRemoveEmptyMethods }
+
+  TRemoveEmptyMethods = Class(TObject)
+  private
+    FTransport: TMessageTransport;
+  Public
+    Constructor Create(aTransport : TMessageTransport);
+    Procedure Execute(const aDocumentURI : String; aPosition: TPosition); virtual;
+    Property Transport : TMessageTransport Read FTransport;
+  end;
+
+implementation
+
+uses
+  { codetools }
+  PascalParserTool,  CodeToolsStructs,
+  { LSP }
+  PasLS.ApplyEdit;
+
+{ TRemoveEmptyMethods }
+
+constructor TRemoveEmptyMethods.Create(aTransport: TMessageTransport);
+begin
+  FTransport:=aTransport;
+end;
+
+procedure TRemoveEmptyMethods.Execute(const aDocumentURI: String;
+  aPosition: TPosition);
+
+Const
+  Attributes =
+      [phpAddClassName,phpDoNotAddSemicolon,phpWithoutParamList,
+       phpWithoutBrackets,phpWithoutClassKeyword,phpWithoutSemicolon];
+
+var
+  aList : TFPList;
+  allEmpty : Boolean;
+  aX,aY : Integer;
+  Msg : String;
+  RemovedProcHeads: TStrings;
+  Code : TCodeBuffer;
+  aRange : TRange;
+
+begin
+  Code:=CodeToolBoss.FindFile(URIToPath(aDocumentUri));
+  if Code=Nil then
+    begin
+    Transport.SendDiagnostic('Cannot find file %s',[aDocumentURI]);
+    exit;
+    end;
+  aY:=aPosition.line+1;
+  aX:=aPosition.character+1;
+  RemovedProcHeads:=Nil;
+  aList:=TFPList.Create;
+  try
+    // check whether cursor is in a class
+    if not CodeToolBoss.FindEmptyMethods(Code,'',aX,aY,AllPascalClassSections,aList,AllEmpty) then
+      begin
+      Msg:=CodeToolBoss.ErrorMessage;
+      if Msg='' then
+        Msg:='No class at caret position';
+      Transport.SendDiagnostic('Cannot find empty methods in file %s: %s',[aDocumentURI,Msg]);
+      exit;
+      end;
+    if not CodeToolBoss.RemoveEmptyMethods(Code,'',aX,aY,AllPascalClassSections,AllEmpty, Attributes, RemovedProcHeads) then
+      Transport.SendDiagnostic('Failed to remove empty methods in file %s',[aDocumentURI])
+    else
+      begin
+      aRange := TRange.Create(0, 0, MaxInt, MaxInt);
+      try
+        DoApplyEdit(Transport,aDocumentURI, Code.Source, aRange);
+      finally
+        aRange.Free;
+      end;
+      end;
+  finally
+    CodeToolBoss.FreeListOfPCodeXYPosition(aList);
+    RemovedProcHeads.Free;
+  end;
+end;
+
+
+
+end.
+

--- a/src/protocol/lspprotocol.lpk
+++ b/src/protocol/lspprotocol.lpk
@@ -178,7 +178,7 @@
     </Files>
     <RequiredPkgs>
       <Item>
-        <PackageName Value="jcfnogui"/>
+        <PackageName Value="jcfbase"/>
       </Item>
       <Item>
         <PackageName Value="CodeTools"/>


### PR DESCRIPTION
Ryan, 
This should fix issue #71.

Several changes:

* The Lazarus team used another name for the Jedi Code Formatter without GUI dependencies. 
    I changed the lspprotocol dependencies accordingly.
* 2 files were missing in my last merge request :disappointed:  I added them.
* I updated the compilation instructions for Lazarus.

It might be a good idea that you also commit your Makefiles: 
people that don't use the IDE can then build with a simple make.