### PR TITLE
* Implement detection of inactive regions in code

### DIFF
--- a/src/protocol/LSP.General.pas
+++ b/src/protocol/LSP.General.pas
@@ -385,6 +385,7 @@ const
     DoLog('  ► includeWorkspaceFoldersAsUnitPaths: ', ServerSettings.includeWorkspaceFoldersAsUnitPaths);
     DoLog('  ► includeWorkspaceFoldersAsIncludePaths: ', ServerSettings.includeWorkspaceFoldersAsIncludePaths);
     DoLog('  ► checkSyntax: ', ServerSettings.checkSyntax);
+    DoLog('  ► checkInactiveRegions: ', ServerSettings.checkInactiveRegions);
     DoLog('  ► publishDiagnostics: ', ServerSettings.publishDiagnostics);
     DoLog('  ► workspaceSymbols: ', ServerSettings.workspaceSymbols);
     DoLog('  ► documentSymbols: ', ServerSettings.documentSymbols);

--- a/src/protocol/LSP.Synchronization.pas
+++ b/src/protocol/LSP.Synchronization.pas
@@ -159,7 +159,7 @@ type
 
 implementation
 uses
-  SysUtils, LSP.Diagnostics, LSP.DocumentSymbol;
+  SysUtils, LSP.Diagnostics, LSP.DocumentSymbol, PasLS.CheckInactiveRegions;
 
 { TDidChangeTextDocumentParams }
 
@@ -244,6 +244,7 @@ begin with Params do
       
     DiagnosticsHandler.CheckSyntax(Transport,Code);
 
+    CheckInactiveRegions(Transport, Code, textDocument.uri);
     //if SymbolManager <> nil then
     //  SymbolManager.FileModified(Code);
     if SymbolManager <> nil then
@@ -288,15 +289,15 @@ end;
 procedure TDidSaveTextDocument.Process(var Params : TDidSaveTextDocumentParams);
 var
   Code: TCodeBuffer;
-begin with Params do
-  begin
+begin
 
-    Code := CodeToolBoss.FindFile(Params.textDocument.LocalPath);
-    if SymbolManager <> nil then
-      SymbolManager.FileModified(Code);
-    DiagnosticsHandler.CheckSyntax(Transport,Code);
-    // ClearDiagnostics(Transport,Code);
-  end;
+  Code := CodeToolBoss.FindFile(Params.textDocument.LocalPath);
+  if SymbolManager <> nil then
+    SymbolManager.FileModified(Code);
+  DiagnosticsHandler.CheckSyntax(Transport,Code);
+  CheckInactiveRegions(Transport, Code, Params.textDocument.uri);
+  // ClearDiagnostics(Transport,Code);
+
 end;
 
 { TDidCloseTextDocumentParams }

--- a/src/protocol/PasLS.CheckInactiveRegions.pas
+++ b/src/protocol/PasLS.CheckInactiveRegions.pas
@@ -1,0 +1,138 @@
+// Pascal Language Server
+// Copyright 2023 Michael Van Canneyt
+
+// This file is part of Pascal Language Server.
+
+// Pascal Language Server is free software: you can redistribute it
+// and/or modify it under the terms of the GNU General Public License
+// as published by the Free Software Foundation, either version 3 of
+// the License, or (at your option) any later version.
+
+// Pascal Language Server is distributed in the hope that it will be
+// useful, but WITHOUT ANY WARRANTY; without even the implied warranty
+// of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with Pascal Language Server.  If not, see
+// <https://www.gnu.org/licenses/>.
+//
+// Adapted from fork at:
+// https://github.com/coolchyni/pascal-language-server
+//  (codetoolsutil unit)
+//
+unit PasLS.CheckInactiveRegions;
+
+{$mode ObjFPC}{$H+}
+
+interface
+
+uses
+  Classes, SysUtils, FileProcs, LazUtils, LazUtilities,
+  // Codetools
+  ExprEval,DefineTemplates,CodeToolManager,CodeCache,LinkScanner,sourcelog,
+  BasicCodeTools,
+  //pasls
+  LSP.Messages, PasLS.InactiveRegions;
+
+type
+
+  { TCheckInactiveRegions }
+
+  TCheckInactiveRegions = class
+  private
+    FTransport: TMessageTransport;
+  Public
+    Constructor Create(aTransport : TMessageTransport);
+    procedure Execute(Code:TCodeBuffer;uri:String);
+    Property Transport : TMessageTransport Read FTransport;
+  end;
+
+Procedure CheckInactiveRegions(aTransport : TMessageTransport; aCode : TCodeBuffer; aURI : String);
+
+
+implementation
+
+uses PasLS.Settings;
+
+Procedure CheckInactiveRegions(aTransport : TMessageTransport; aCode : TCodeBuffer; aURI : String);
+begin
+  if ServerSettings.CheckInactiveRegions then
+    With TCheckInactiveRegions.Create(aTransport) do
+      try
+        aTransport.SendDiagnostic('Checking inactive regions');
+        Execute(aCode,aURI);
+      finally
+        Free;
+      end;
+end;
+
+constructor TCheckInactiveRegions.Create(aTransport: TMessageTransport);
+begin
+  FTransport:=aTransport;
+end;
+
+procedure TCheckInactiveRegions.Execute(Code:TCodeBuffer;uri:String);
+
+  Procedure GetDirectivePos(Scanner: TLinkScanner;Dir : PLSDirective; Out Line,Col : integer);
+  var
+    acode:Pointer;
+    cursorPos:Integer;
+  begin
+    Scanner.CleanedPosToCursor(Dir^.CleanPos,cursorPos,acode);
+    TSourceLog(acode).AbsoluteToLineCol(cursorPos,line,col);
+  end;
+
+var   
+  Notification: TInactiveRegionsNotification;
+  Regions: TRegionsItems;
+  CurrentRegion: TInputRegion;
+  Scanner: TLinkScanner;
+  Dir: PLSDirective;
+  i, line,col: Integer;
+  DirectiveText : string;
+
+begin
+  if (Code=nil) or Not CodeToolBoss.ExploreUnitDirectives(Code,Scanner) then
+    exit;
+  Notification := TInactiveRegionsNotification.Create;
+  try
+    Notification.InactiveRegionParams.uri:=uri;
+    // Easy access
+    Regions:=Notification.InactiveRegionParams.regions;
+    CurrentRegion:=nil;
+    for i:=0 to Scanner.DirectiveCount-1 do
+      begin
+        Dir:=Scanner.Directives[i];
+        if (Dir^.Code<>Pointer(Code)) then
+          Continue;
+        GetDirectivePos(Scanner,Dir,Line,Col);
+        DirectiveText:=ExtractCommentContent(Scanner.CleanedSrc,Dir^.CleanPos,Scanner.NestedComments);
+        Case Dir^.State of
+        lsdsInactive:
+          if Not Assigned(CurrentRegion) then
+            begin
+              CurrentRegion:=Regions.Add;
+              CurrentRegion.startline:=line;
+              CurrentRegion.startCol:=col+length(DirectiveText)+2;
+              CurrentRegion.endline:=999999; // will be corrected when end of region is found
+            end;
+        lsdsActive:
+          if Assigned(CurrentRegion) then
+            begin
+              CurrentRegion.endline:=line;
+              CurrentRegion.endCol:=col;
+              CurrentRegion:=Nil;
+            end;
+        lsdsSkipped:
+           ;
+        end;
+      end;
+    // We must always send: if after an edit the previous ranges become invalid, we need to notify the client.
+    Notification.Send(Transport);
+  finally
+    Notification.Free;
+  end;
+end;
+
+end.

--- a/src/protocol/PasLS.InactiveRegions.pas
+++ b/src/protocol/PasLS.InactiveRegions.pas
@@ -1,0 +1,140 @@
+// Pascal Language Server
+// Copyright 2020 Ryan Joseph
+
+// This file is part of Pascal Language Server.
+
+// Pascal Language Server is free software: you can redistribute it
+// and/or modify it under the terms of the GNU General Public License
+// as published by the Free Software Foundation, either version 3 of
+// the License, or (at your option) any later version.
+
+// Pascal Language Server is distributed in the hope that it will be
+// useful, but WITHOUT ANY WARRANTY; without even the implied warranty
+// of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with Pascal Language Server.  If not, see
+// <https://www.gnu.org/licenses/>.
+
+unit PasLS.InactiveRegions;
+
+{$mode objfpc}{$H+}
+
+interface
+
+uses
+  { Rtl }
+  SysUtils, Classes,
+  { Pasls }
+  LSP.Base, LSP.BaseTypes, LSP.Messages;
+
+type
+  { TInputRegion }
+  TInputRegion = class(TCollectionItem)
+  private
+    fStartline:Integer;
+    fStartCol:Integer;
+    fEndline:Integer;
+    fEndCol:Integer;
+  Public
+    Procedure Assign(aSource : TPersistent); override;
+  published
+    property startLine: Integer read fStartline write fStartline;
+    property startCol: Integer read fStartCol write fStartCol;
+    property endLine: Integer read fEndline write fEndline;
+    property endCol: Integer read fEndCol write fEndCol;
+  end;
+   
+  TRegionsItems = specialize TGenericCollection<TInputRegion>;
+
+  { TInactiveRegionParams }
+  
+  TInactiveRegionParams=class(TLSPStreamable)
+  private
+    fUri:string;
+    fFileVersion:Integer;
+    fRegions:TRegionsItems;
+    procedure SetRegions(AValue: TRegionsItems);
+  Public
+    Constructor Create; override;
+    Destructor Destroy; override;
+  published
+    property uri : string read fUri write fUri;
+    property fileVersion : Integer read fFileVersion write fFileVersion;
+    property regions : TRegionsItems read fRegions write SetRegions;
+  end;
+
+
+  { TInactiveRegionsNotification }
+  { The  message notification is sent from a server to a client to ask 
+    the client to display a inactive region in the user interface. }
+
+  TInactiveRegionsNotification = class(TNotificationMessage)
+  private
+    function GetParams: TInactiveRegionParams;
+  public
+    constructor Create; override;
+    Property InactiveRegionParams: TInactiveRegionParams Read GetParams;
+    destructor Destroy; override;
+  end;
+
+implementation
+
+{ TInputRegion }
+
+procedure TInputRegion.Assign(aSource: TPersistent);
+
+var
+  Reg : TInputRegion absolute aSource;
+
+begin
+  if (aSource is TInputRegion) then
+    begin
+    Startline:=Reg.Startline;
+    StartCol:=Reg.StartCol;
+    Endline:=Reg.EndLine;
+    EndCol:=Reg.EndCol;
+    end
+  else
+    inherited Assign(aSource);
+end;
+
+{ TInactiveRegionParams }
+
+procedure TInactiveRegionParams.SetRegions(AValue: TRegionsItems);
+begin
+  if fRegions=AValue then Exit;
+  fRegions.Assign(AValue);
+end;
+
+constructor TInactiveRegionParams.Create;
+begin
+  inherited Create;
+  fRegions:=TRegionsItems.Create;
+end;
+
+destructor TInactiveRegionParams.Destroy;
+begin
+  FreeAndNil(fRegions);
+  inherited Destroy;
+end;
+
+function TInactiveRegionsNotification.GetParams: TInactiveRegionParams;
+begin
+  Result:=(Inherited Params) as TInactiveRegionParams
+end;
+
+constructor TInactiveRegionsNotification.Create;
+begin
+  params := TInactiveRegionParams.Create;
+  method := 'pasls.inactiveRegions';
+end;
+
+destructor TInactiveRegionsNotification.Destroy;
+begin
+  FreeAndNil(fparams);
+  inherited;
+end;
+
+end.

--- a/src/protocol/PasLS.InactiveRegions.pas
+++ b/src/protocol/PasLS.InactiveRegions.pas
@@ -1,5 +1,5 @@
 // Pascal Language Server
-// Copyright 2020 Ryan Joseph
+// Copyright 2023 Michael Van Canneyt
 
 // This file is part of Pascal Language Server.
 

--- a/src/protocol/PasLS.Settings.pas
+++ b/src/protocol/PasLS.Settings.pas
@@ -93,6 +93,8 @@ type
     property ignoreTextCompletions: Boolean read fBooleans[10] write fBooleans[10];
     // config file or directory to read settings from (will support multiple formats)
     property config: String read fConfig write fConfig;
+    // enable document symbols
+    property checkInactiveRegions : Boolean read fBooleans[11] write fBooleans[11];
 
     function CanProvideWorkspaceSymbols: boolean;
   public

--- a/src/protocol/lspprotocol.lpk
+++ b/src/protocol/lspprotocol.lpk
@@ -191,6 +191,14 @@
         <Filename Value="PasLS.Command.RemoveEmptyMethods.pas"/>
         <UnitName Value="PasLS.Command.RemoveEmptyMethods"/>
       </Item>
+      <Item>
+        <Filename Value="PasLS.CheckInactiveRegions.pas"/>
+        <UnitName Value="PasLS.CheckInactiveRegions"/>
+      </Item>
+      <Item>
+        <Filename Value="PasLS.InactiveRegions.pas"/>
+        <UnitName Value="PasLS.InactiveRegions"/>
+      </Item>
     </Files>
     <RequiredPkgs>
       <Item>

--- a/src/protocol/lspprotocol.pas
+++ b/src/protocol/lspprotocol.pas
@@ -19,7 +19,8 @@ uses
   LSP.Messages, PasLS.Parser, PasLS.Formatter, PasLS.InvertAssign, 
   PasLS.RemoveEmptyMethods, PasLS.ApplyEdit, PasLS.Command.FormatCode, 
   PasLS.Command.CompleteCode, PasLS.Command.InvertAssignment, 
-  PasLS.Command.RemoveEmptyMethods, LazarusPackageIntf;
+  PasLS.Command.RemoveEmptyMethods, PasLS.CheckInactiveRegions, 
+  PasLS.InactiveRegions, LazarusPackageIntf;
 
 implementation
 


### PR DESCRIPTION
Ryan, 
This implements detection of inactive regions in code, meaning that
```pascal

{$IFDEF SOMETHING}
  DoSomething;
{$ENDIF}
```
Will render 'DoSomething' greyed out if SOMETHING is not defined.

It requires client-side support, the patch implementing that in VS-Code will be submitted as soon as I finish this PR.