### PR TITLE
Improved searchpath handling

### DIFF
--- a/src/socketserver/paslssock.lpi
+++ b/src/socketserver/paslssock.lpi
@@ -67,6 +67,9 @@
       <Item>
         <Name Value="EFOpenError"/>
       </Item>
+      <Item>
+        <Name Value="ECodeToolUnitNotFound"/>
+      </Item>
     </Exceptions>
   </Debugging>
 </CONFIG>

--- a/src/socketserver/paslssock.lpr
+++ b/src/socketserver/paslssock.lpr
@@ -171,7 +171,7 @@ var
 
 begin
   Close(Output);
-  Assign(Output,'/tmp/paslssock-out.log');
+  Assign(Output,GetTempDir(false)+'paslssock-out.log');
   SetTextBuf(Output,Buffer,SizeOf(Buffer));
   Rewrite(output);
   Application:=TPasLSPSocketServerApp.Create(nil);

--- a/src/socketserver/paslssock.lpr
+++ b/src/socketserver/paslssock.lpr
@@ -27,6 +27,7 @@ uses
   {$IFDEF UNIX}
   cthreads, cwstring,
   {$ENDIF}
+  LazLogger,
   Classes, SysUtils, CustApp, IniFiles, LSP.AllCommands,  LSP.Messages,
   LSP.Base, PasLS.Settings, PasLSSock.Config, PasLS.SocketDispatcher;
 
@@ -166,7 +167,13 @@ end;
 
 var
   Application: TPasLSPSocketServerApp;
+  Buffer: Array[1..100*1024] of byte;
+
 begin
+  Close(Output);
+  Assign(Output,'/tmp/paslssock-out.log');
+  SetTextBuf(Output,Buffer,SizeOf(Buffer));
+  Rewrite(output);
   Application:=TPasLSPSocketServerApp.Create(nil);
   Application.Title:='Pascal LSP socket server application';
   Application.Run;


### PR DESCRIPTION
Ryan

I have changed the way the search path is handled: 
Previously it was added to the FPCOptions string, which is then subsequently  taken into account by the codetools. 

We have a project with 800 directories, the combined length of the include and unit path is then way over 128k characters. 

Since the codetools execute fpc with the FPCOptions on the commandline, this fails because the OS imposes limits on the length of the command-line (32k windows, 64k linux).

Instead, the directories of the workspace are not added in the FPCOptions, but are directly passed to the Lazarus codetools. Since the LSP server does not use the fpc options for anything else than feeding it to codetools, 
the resulting behaviour of the codetools  is the same.

I also let the socket server write the log output to a file with a larger buffer (it takes seconds to write the 128k path to the logs otherwise). This last change does not affect the 'pasls' process, only the socket server.
