### PR TITLE
Fixed segfault when a notification is received with an id

### DIFF
--- a/lsp.pas
+++ b/lsp.pas
@@ -259,6 +259,7 @@ var
 begin
   Input := specialize TLSPStreaming<T>.ToObject(Params);
   Process(Input);
+  Result := nil;
 end;
 
 { TLSPDispatcher }


### PR DESCRIPTION
When a notification is received with an id (like 'initialized') an error message should be returned, but instead the application crashed.