### PR TITLE
Optimize DocumentSymbol 

### DIFF
--- a/src/protocol/PasLS.Settings.pas
+++ b/src/protocol/PasLS.Settings.pas
@@ -28,8 +28,8 @@ uses
 
 { Global String Constants }
 const
-  kSymbolName_Interface = '==== INTERFACE ====';
-  kSymbolName_Implementation = '==== IMPLEMENTATION ====';
+  kSymbolName_Interface = 'interface';
+  kSymbolName_Implementation = 'implementation';
 
 type
   TOverloadPolicy = ( __UNUSED__,

--- a/src/serverprotocol/PasLS.CodeUtils.pas
+++ b/src/serverprotocol/PasLS.CodeUtils.pas
@@ -219,7 +219,11 @@ begin
           DetailString := 'Unit '+UnitName
         // show contants values as details
         else if Identifier.Node.Desc = ctnConstDefinition then
-          DetailString := Identifier.Tool.ExtractNode(Identifier.Node, []);
+          begin
+            Node:=Identifier.Tool.FindTypeNodeOfDefinition(Identifier.Node);
+            if Node<>nil then
+              DetailString:=Identifier.Tool.ExtractNode(Node,[]);
+          end;
       end;
     ctnEnumIdentifier:
       begin

--- a/src/serverprotocol/PasLS.Settings.pas
+++ b/src/serverprotocol/PasLS.Settings.pas
@@ -28,8 +28,8 @@ uses
 
 { Global String Constants }
 const
-  kSymbolName_Interface = '==== INTERFACE ====';
-  kSymbolName_Implementation = '==== IMPLEMENTATION ====';
+  kSymbolName_Interface = 'interface';
+  kSymbolName_Implementation = 'implementation';
 
 type
   TOverloadPolicy = ( __UNUSED__,

--- a/src/serverprotocol/PasLS.Symbols.pas
+++ b/src/serverprotocol/PasLS.Symbols.pas
@@ -72,7 +72,7 @@ type
     destructor Destroy; override;
     procedure Clear;
     procedure SerializeSymbols;
-    function AddSymbol(Name: String; Kind: TSymbolKind; FileName: String; Line, Column, RangeLen: Integer): TSymbol;
+    function AddSymbol(Name: String; Kind: TSymbolKind; FileName: String; Line, Column: Integer;EndLine,EndCol: Integer): TSymbol;
     function RequestReload: boolean;
     function Count: integer; inline;
     property RawJSON: String read GetRawJSON;
@@ -281,7 +281,7 @@ begin
     Result := true;
 end;
 
-function TSymbolTableEntry.AddSymbol(Name: String; Kind: TSymbolKind; FileName: String; Line, Column, RangeLen: Integer): TSymbol;
+function TSymbolTableEntry.AddSymbol(Name: String; Kind: TSymbolKind; FileName: String; Line, Column: Integer;EndLine,EndCol: Integer): TSymbol;
 
 var
   Symbol: TSymbol;
@@ -291,7 +291,7 @@ begin
   Symbol.name := Name;
   Symbol.kind := Kind;
   Symbol.location.URI:=PathToURI(FileName);
-  Symbol.location.Range.SetRange(Line-1,Column-1,RangeLen);
+  Symbol.location.Range.SetRange(Line-1,Column-1,EndLine-1 ,EndCol-1);
   { TODO: In the latest version of LSP container name is supported
     so consider adding some context for the hierarchy }
   //Symbol.containerName := 'Interface > TClass > Function';
@@ -390,7 +390,7 @@ end;
 
 function TSymbolExtractor.AddSymbol(Node: TCodeTreeNode; Kind: TSymbolKind; Name: String; Container: String): TSymbol;
 var
-  CodePos: TCodeXYPosition;
+  CodePos,EndPos: TCodeXYPosition;
   FileName: String;
 begin
   {$ifdef SYMBOL_DEBUG}
@@ -398,6 +398,7 @@ begin
   {$endif}
 
   Tool.CleanPosToCaret(Node.StartPos, CodePos);
+  Tool.CleanPosToCaret(Node.EndPos,EndPos);
   
   // clear existing symbols in symbol database
   // we don't know which include files are associated
@@ -413,7 +414,7 @@ begin
         end;
     end;
     
-  Result := Entry.AddSymbol(Name, Kind, CodePos.Code.FileName, CodePos.Y, CodePos.X, Node.EndPos - Node.StartPos);
+  Result := Entry.AddSymbol(Name, Kind, CodePos.Code.FileName, CodePos.Y, CodePos.X, EndPos.Y,EndPos.X);
 end;
 
 procedure TSymbolExtractor.ExtractObjCClassMethods(ClassNode, Node: TCodeTreeNode);
@@ -1105,7 +1106,7 @@ begin
   //if Entry.Modified then
     Reload(Path, False);
 
-  if Entry <> nil then
+  if (Entry <> nil) and (Entry.RawJSON <> '') then
     Result := TJSONSerializedArray.Create(Entry.RawJSON)
   else
     Result := nil;

--- a/src/serverprotocol/PasLS.Symbols.pas
+++ b/src/serverprotocol/PasLS.Symbols.pas
@@ -94,7 +94,7 @@ type
     function AddSymbol(Node: TCodeTreeNode; Kind: TSymbolKind): TSymbol; overload;
     function AddSymbol(Node: TCodeTreeNode; Kind: TSymbolKind; Name: String; Container: String = ''): TSymbol; overload;
     procedure ExtractCodeSection(Node: TCodeTreeNode);
-    procedure ExtractProcedure(ParentNode, Node: TCodeTreeNode);
+    function ExtractProcedure(ParentNode, Node: TCodeTreeNode):TSymbol;
     procedure ExtractTypeDefinition(TypeDefNode, Node: TCodeTreeNode); 
     procedure ExtractObjCClassMethods(ClassNode, Node: TCodeTreeNode);
   public
@@ -188,7 +188,7 @@ uses
   SysUtils, FileUtil, DateUtils, fpjsonrtti, 
   { Code Tools }
   CodeAtom,
-  FindDeclarationTool, KeywordFuncLists,
+  FindDeclarationTool, KeywordFuncLists,PascalParserTool,
   { Protocol }
   PasLS.Settings;
 
@@ -521,20 +521,21 @@ begin
     end;
 end;
 
-procedure TSymbolExtractor.ExtractProcedure(ParentNode, Node: TCodeTreeNode);
+function TSymbolExtractor.ExtractProcedure(ParentNode, Node: TCodeTreeNode):TSymbol;
 var
   Child: TCodeTreeNode;
-  Name: ShortString;
+  Name,ContainerName,Key: ShortString;
   Symbol: TSymbol;
 begin
+  result := nil;
   PrintNodeDebug(Node);
-    
-  if ParentNode <> nil then
-    Name := Tool.ExtractProcName(ParentNode, [])+'.'+Tool.ExtractProcName(Node, [])
-  else
-    Name := Tool.ExtractProcName(Node, []);
 
-  Symbol := TSymbol(OverloadMap.Find(Name));
+  containerName:=Tool.ExtractClassNameOfProcNode(Node);
+  Name := Tool.ExtractProcName(Node, [phpWithoutClassName]);
+
+  key:=IntToStr(CodeSection)+'.'+containerName+'.'+Name;
+  Symbol := TSymbol(OverloadMap.Find(key));
+
   if Symbol <> nil then
     begin
       { TODO: when newest LSP version is released on package control
@@ -559,7 +560,8 @@ begin
     end;
 
   Symbol := AddSymbol(Node, TSymbolKind._Function, Name);
-  OverloadMap.Add(Symbol.name, Symbol);
+  Symbol.containerName:=containerName;
+  OverloadMap.Add(Key, Symbol);
 
   // recurse into procedures to find nested procedures
 
@@ -578,14 +580,20 @@ begin
           Child := Child.NextBrother;
         end;
     end;
+  result := Symbol;
 end;
 
 procedure TSymbolExtractor.ExtractCodeSection(Node: TCodeTreeNode); 
 var
+  Symbol,LastClassSymbol: TSymbol;
   Child: TCodeTreeNode;
   Scanner: TLinkScanner;
   LinkIndex: Integer;
+  IsImplementation:Boolean;
 begin
+  IsImplementation:=(Node.Parent<>nil) and  (Node.Parent.Desc=ctnImplementation);
+  LastClassSymbol:=nil;
+
   while Node <> nil do
     begin
       PrintNodeDebug(Node);
@@ -609,8 +617,8 @@ begin
           case Node.Desc of
             ctnInterface:
               AddSymbol(Node, TSymbolKind._Namespace, kSymbolName_Interface);
-            ctnImplementation:
-              AddSymbol(Node, TSymbolKind._Namespace, kSymbolName_Implementation);
+            //ctnImplementation:
+            //  AddSymbol(Node, TSymbolKind._Namespace, kSymbolName_Implementation);
           end;
           CodeSection := Node.Desc;
           Inc(IndentLevel);
@@ -656,7 +664,23 @@ begin
           end;
 
         ctnProcedure:
-          ExtractProcedure(nil, Node);
+           begin
+
+            Symbol:= ExtractProcedure(nil, Node);
+
+            if (Symbol<>nil) and  (Symbol.containerName<>'') then
+              begin
+                 if (LastClassSymbol=nil) or  (Symbol.containerName<>LastClassSymbol.name) then
+                 begin
+                     LastClassSymbol:=AddSymbol(Node,TSymbolKind._Class,Symbol.containerName);
+                 end
+                 else
+                 begin
+                    LastClassSymbol.location.range.&end:=Symbol.location.range.&end;
+                 end;
+              end;
+
+          end;
       end;
 
       Node := Node.NextBrother;


### PR DESCRIPTION
Optimize DocumentSymbol to display functions hierarchically under their respective classes.
fix: documentSymbol loacation.range.end is not correct