### PR TITLE
Fix: Return proper identifier range in goto declaration/definition/implementation

### DIFF
--- a/src/serverprotocol/PasLS.GotoDeclaration.pas
+++ b/src/serverprotocol/PasLS.GotoDeclaration.pas
@@ -40,7 +40,7 @@ type
 implementation
 
 uses
-  PasLS.Diagnostics;
+  PasLS.Diagnostics, PasLS.CodeUtils;
   
 function TGotoDeclaraction.Process(var Params: TTextDocumentPositionParams): TLocation;
 var
@@ -57,7 +57,9 @@ begin with Params do
 
     if CodeToolBoss.FindDeclaration(Code, X + 1, Y + 1, NewCode, NewX, NewY, NewTopLine, BlockTopLine, BlockBottomLine) then
       begin
-        Result := TLocation.Create(NewCode.Filename,NewY - 1,NewX-1,0);
+        Result := TLocation.Create;
+        Result.uri := PathToURI(NewCode.Filename);
+        Result.range := GetIdentifierRangeAtPos(NewCode, NewX, NewY - 1);
       end
     else
       begin

--- a/src/serverprotocol/PasLS.GotoDefinition.pas
+++ b/src/serverprotocol/PasLS.GotoDefinition.pas
@@ -42,7 +42,7 @@ type
 implementation
 
 uses
-  PasLS.Diagnostics;
+  PasLS.Diagnostics, PasLS.CodeUtils;
   
 function TGotoDefinition.Process(var Params: TTextDocumentPositionParams): TLocation;
 var
@@ -75,7 +75,9 @@ begin with Params do
     }
     if CodeToolBoss.FindDeclaration(Code, X + 1, Y + 1, NewCode, NewX, NewY, NewTopLine, BlockTopLine, BlockBottomLine) then
       begin
-        Result := TLocation.Create(NewCode.Filename,NewY - 1, NewX - 1,0)
+        Result := TLocation.Create;
+        Result.uri := PathToURI(NewCode.Filename);
+        Result.range := GetIdentifierRangeAtPos(NewCode, NewX, NewY - 1);
       end
     else
       begin

--- a/src/serverprotocol/PasLS.GotoImplementation.pas
+++ b/src/serverprotocol/PasLS.GotoImplementation.pas
@@ -42,7 +42,7 @@ type
 implementation
 
 uses
-  PasLS.Diagnostics, LSP.Diagnostics;
+  PasLS.Diagnostics, LSP.Diagnostics, PasLS.CodeUtils;
   
 function TGotoImplementation.Process(var Params: TTextDocumentPositionParams): TLocation;
 var
@@ -57,10 +57,12 @@ begin with Params do
     X := position.character;
     Y := position.line;
 
-    if CodeToolBoss.JumpToMethod(Code, X + 1, Y + 1, 
+    if CodeToolBoss.JumpToMethod(Code, X + 1, Y + 1,
       NewCode, NewX, NewY, NewTopLine, BlockTopLine, BlockBottomLine, RevertableJump) then
       begin
-        Result := TLocation.Create(NewCode.Filename,NewY - 1, NewX - 1,0);
+        Result := TLocation.Create;
+        Result.uri := PathToURI(NewCode.Filename);
+        Result.range := GetIdentifierRangeAtPos(NewCode, NewX, NewY - 1);
       end
     else
       begin


### PR DESCRIPTION
## Summary

- Fix zero-length range issue in textDocument/declaration, textDocument/definition, and textDocument/implementation responses
- Use existing GetIdentifierRangeAtPos function from PasLS.CodeUtils to return the full identifier range

## Problem

Previously, TLocation was created with Span=0, resulting in a zero-length range where start == end.

## Solution

Now uses GetIdentifierRangeAtPos (which was already available and used by DocumentHighlight) to return the proper range.

## Files Changed

- src/serverprotocol/PasLS.GotoDeclaration.pas
- src/serverprotocol/PasLS.GotoDefinition.pas
- src/serverprotocol/PasLS.GotoImplementation.pas