### PR TITLE
Add documentation comments to hover response

### DIFF
--- a/src/serverprotocol/PasLS.Hover.pas
+++ b/src/serverprotocol/PasLS.Hover.pas
@@ -39,14 +39,93 @@ Type
 implementation
 
 uses
-  SysUtils;
+  SysUtils, Classes, BasicCodeTools;
+
+function ExtractPasDocComments(Code: TCodeBuffer; X, Y: Integer): String;
+var
+  ListOfPCodeXYPosition: TFPList;
+  i: Integer;
+  CodeXYPos: PCodeXYPosition;
+  CommentCode: TCodeBuffer;
+  CommentStart, CommentEnd: Integer;
+  CommentStr, Line: String;
+  Comments: TStringList;
+  NestedComments: Boolean;
+begin
+  Result := '';
+  ListOfPCodeXYPosition := nil;
+
+  try
+    if not CodeToolBoss.GetPasDocComments(Code, X, Y, ListOfPCodeXYPosition) then
+      Exit;
+    if (ListOfPCodeXYPosition = nil) or (ListOfPCodeXYPosition.Count = 0) then
+      Exit;
+
+    Comments := TStringList.Create;
+    try
+      NestedComments := CodeToolBoss.GetNestedCommentsFlagForFile(Code.Filename);
+
+      for i := 0 to ListOfPCodeXYPosition.Count - 1 do
+      begin
+        CodeXYPos := PCodeXYPosition(ListOfPCodeXYPosition[i]);
+        CommentCode := CodeXYPos^.Code;
+        CommentCode.LineColToPosition(CodeXYPos^.Y, CodeXYPos^.X, CommentStart);
+
+        if (CommentStart < 1) or (CommentStart > CommentCode.SourceLength) then
+          Continue;
+
+        CommentEnd := FindCommentEnd(CommentCode.Source, CommentStart, NestedComments);
+        CommentStr := Copy(CommentCode.Source, CommentStart, CommentEnd - CommentStart);
+
+        // Clean up comment markers
+        CommentStr := Trim(CommentStr);
+        if CommentStr = '' then
+          Continue;
+
+        // Handle // and /// style comments
+        if (Length(CommentStr) >= 2) and (CommentStr[1] = '/') and (CommentStr[2] = '/') then
+        begin
+          // Check for /// style (PasDoc)
+          if (Length(CommentStr) >= 3) and (CommentStr[3] = '/') then
+            Line := Copy(CommentStr, 4, Length(CommentStr))
+          else
+            Line := Copy(CommentStr, 3, Length(CommentStr));
+          // Remove leading space
+          if (Length(Line) > 0) and (Line[1] = ' ') then
+            Line := Copy(Line, 2, Length(Line));
+          Comments.Add(Line);
+        end
+        // Handle { } style comments
+        else if (Length(CommentStr) >= 2) and (CommentStr[1] = '{') then
+        begin
+          Line := Copy(CommentStr, 2, Length(CommentStr) - 2); // Remove { and }
+          Comments.Add(Trim(Line));
+        end
+        // Handle (* *) style comments
+        else if (Length(CommentStr) >= 4) and (CommentStr[1] = '(') and (CommentStr[2] = '*') then
+        begin
+          Line := Copy(CommentStr, 3, Length(CommentStr) - 4); // Remove (* and *)
+          Comments.Add(Trim(Line));
+        end
+        else
+          Comments.Add(CommentStr);
+      end;
+
+      if Comments.Count > 0 then
+        Result := Comments.Text;
+    finally
+      Comments.Free;
+    end;
+  finally
+    CodeToolBoss.FreeListOfPCodeXYPosition(ListOfPCodeXYPosition);
+  end;
+end;
 
 function THoverRequest.Process(var Params: TTextDocumentPositionParams): THoverResponse;
 var
-
   Code: TCodeBuffer;
   X, Y: Integer;
-  Hint: String;
+  Hint, DocComments: String;
 begin with Params do
   begin
     Code := CodeToolBoss.FindFile(textDocument.LocalPath);
@@ -68,7 +147,16 @@ begin with Params do
 
     // https://facelessuser.github.io/sublime-markdown-popups/
     // Wrap hint in markdown code
-    Hint:='```pascal'+#10+Hint+#10+'```';
+    Hint := '```pascal' + #10 + Hint + #10 + '```';
+
+    // Try to get documentation comments
+    try
+      DocComments := ExtractPasDocComments(Code, X + 1, Y + 1);
+      if DocComments <> '' then
+        Hint := Hint + #10 + #10 + '---' + #10 + DocComments;
+    except
+      // Ignore errors when extracting comments
+    end;
 
     Result := THoverResponse.Create;
     Result.contents.PlainText:=False;


### PR DESCRIPTION
## Summary

- Use `CodeToolBoss.GetPasDocComments` to extract documentation comments preceding symbol declarations
- Include doc comments in hover response, separated by markdown horizontal rule
- Supports all Pascal comment styles: `///`, `//`, `{ }`, `(* *)`

## Example

Before:
```
procedure DoSomething(X: Integer);
```

After:
```
procedure DoSomething(X: Integer);

---
This procedure does something important.
- It takes an integer parameter X
- Returns nothing
```

## Test plan

- [x] Build pasls successfully
- [x] Test hover on symbols with `///` comments
- [x] Test hover on symbols with `//` comments  
- [x] Test hover on symbols with `{ }` comments