### PR TITLE
Use FindMainDeclaration to skip forward declarations

### DIFF
--- a/src/serverprotocol/PasLS.GotoDefinition.pas
+++ b/src/serverprotocol/PasLS.GotoDefinition.pas
@@ -49,31 +49,28 @@ var
   Code: TCodeBuffer;
   NewCode: TCodeBuffer;
   X, Y: Integer;
-  NewX, NewY, NewTopLine, BlockTopLine, BlockBottomLine: integer;
+  NewX, NewY, NewTopLine: integer;
 begin with Params do
   begin
     Code := CodeToolBoss.FindFile(textDocument.localPath);
     X := position.character;
     Y := position.line;
     { 
-      NOTE: currently goto definition is supported as goto declaration
+      NOTE: Use FindMainDeclaration to skip forward declarations and find
+      the main/complete declaration. This is the correct behavior for
+      "Go to Definition" as opposed to "Go to Declaration".
       
-      There is a definition for the following identifiers:
-        
-        - Methods
-
-      There is no definition for the following identifiers:
-  
-        - Function forwards
-        - Functions in the interface section
-        - External functions
-        - Class forwards
-        - External ObjC classes
-
-        https://www.cprogramming.com/declare_vs_define.html
-        https://stackoverflow.com/questions/1410563/what-is-the-difference-between-a-definition-and-a-declaration
+      For example, with:
+        type
+          IDocList = interface;  // forward declaration
+          ...
+          IDocList = interface(IDocAny)  // main declaration
+            ...
+          end;
+      
+      FindMainDeclaration returns the main declaration location.
     }
-    if CodeToolBoss.FindDeclaration(Code, X + 1, Y + 1, NewCode, NewX, NewY, NewTopLine, BlockTopLine, BlockBottomLine) then
+    if CodeToolBoss.FindMainDeclaration(Code, X + 1, Y + 1, NewCode, NewX, NewY, NewTopLine) then
       begin
         Result := TLocation.Create;
         Result.uri := PathToURI(NewCode.Filename);

--- a/src/serverprotocol/PasLS.Hover.pas
+++ b/src/serverprotocol/PasLS.Hover.pas
@@ -127,7 +127,7 @@ var
   X, Y: Integer;
   Hint, DocComments: String;
   DeclCode: TCodeBuffer;
-  DeclX, DeclY, NewTopLine, BlockTopLine, BlockBottomLine: Integer;
+  DeclX, DeclY, NewTopLine: Integer;
 begin with Params do
   begin
     Code := CodeToolBoss.FindFile(textDocument.LocalPath);
@@ -152,15 +152,15 @@ begin with Params do
     Hint := '```pascal' + #10 + Hint + #10 + '```';
 
     // Try to get documentation comments
-    // First find the declaration location, then get comments from there
+    // Use FindMainDeclaration to skip forward declarations and find the main
+    // declaration where documentation comments are typically located.
     try
       DocComments := '';
-      // Try to find declaration location first
-      if CodeToolBoss.FindDeclaration(Code, X + 1, Y + 1, DeclCode, DeclX, DeclY,
-                                       NewTopLine, BlockTopLine, BlockBottomLine) then
+      // Try to find main declaration location (skips forward declarations)
+      if CodeToolBoss.FindMainDeclaration(Code, X + 1, Y + 1, DeclCode, DeclX, DeclY, NewTopLine) then
         DocComments := ExtractPasDocComments(DeclCode, DeclX, DeclY)
       else
-        // If FindDeclaration fails, try current position (might be at declaration already)
+        // If FindMainDeclaration fails, try current position (might be at declaration already)
         DocComments := ExtractPasDocComments(Code, X + 1, Y + 1);
 
       if DocComments <> '' then
@@ -175,7 +175,6 @@ begin with Params do
     Result.range.SetRange(Y, X);
   end;
 end;
-
 
 end.
 


### PR DESCRIPTION
## Summary

- Changes `FindDeclaration` to `FindMainDeclaration` in GotoDefinition and Hover handlers
- Ensures we skip forward declarations and find the main/complete declaration
- Improves accuracy for "Go to Definition" navigation
- Fixes documentation comment retrieval in hover tooltips

## Example

With interface forward declarations:
```pascal
type
  IDocList = interface;  // forward declaration
  ...
  /// Documentation here
  IDocList = interface(IDocAny)  // main declaration with doc comments
    ...
  end;
```

`FindMainDeclaration` now correctly returns the main declaration location where documentation comments are located.

## Changes

- `src/serverprotocol/PasLS.GotoDefinition.pas`: Use FindMainDeclaration
- `src/serverprotocol/PasLS.Hover.pas`: Use FindMainDeclaration
- Removed unused BlockTopLine/BlockBottomLine parameters
- Updated code comments to explain the change

## Test Plan

- [x] Verified code compiles
- [x] Tested in VS Code with forward-declared interfaces
- [x] Verified hover tooltips show documentation from main declarations