### PR TITLE
Fix: Make symbol range end position exclusive per LSP specification

### DIFF
--- a/src/serverprotocol/PasLS.Symbols.pas
+++ b/src/serverprotocol/PasLS.Symbols.pas
@@ -392,6 +392,7 @@ function TSymbolExtractor.AddSymbol(Node: TCodeTreeNode; Kind: TSymbolKind; Name
 var
   CodePos,EndPos: TCodeXYPosition;
   FileName: String;
+  LineText: String;
 begin
   {$ifdef SYMBOL_DEBUG}
   writeln(IndentLevelString(IndentLevel + 1), '* ', Name);
@@ -399,7 +400,23 @@ begin
 
   Tool.CleanPosToCaret(Node.StartPos, CodePos);
   Tool.CleanPosToCaret(Node.EndPos,EndPos);
-  
+
+  // Fix for LSP Range specification: end position must be exclusive
+  // Move EndPos one position forward to make it exclusive
+  if (EndPos.Code <> nil) and (EndPos.Y > 0) and (EndPos.Y <= EndPos.Code.LineCount) then
+    begin
+      LineText := EndPos.Code.GetLine(EndPos.Y - 1, false);
+      // X is 1-based, so X <= Length means we're within the line
+      if EndPos.X <= Length(LineText) then
+        Inc(EndPos.X)
+      else
+        begin
+          // Move to next line if already past end of current line (use 1-based indexing)
+          Inc(EndPos.Y);
+          EndPos.X := 1;
+        end;
+    end;
+
   // clear existing symbols in symbol database
   // we don't know which include files are associated
   // with each unit so we need to check each time
@@ -413,7 +430,7 @@ begin
           RelatedFiles.Add(FileName, @CodePos);
         end;
     end;
-    
+
   Result := Entry.AddSymbol(Name, Kind, CodePos.Code.FileName, CodePos.Y, CodePos.X, EndPos.Y,EndPos.X);
 end;
 


### PR DESCRIPTION
## Problem

The symbol range `end` position returned by pasls does not comply with the LSP specification. According to the [LSP 3.17 specification](https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#range):

> "A range is comparable to a selection in an editor. Therefore, the **end position is exclusive**."

In the current implementation, the `end` position points to the last character of a symbol rather than the position after it. This causes operations like `replace_symbol_body` to miss the last character (typically a semicolon) of symbol definitions.

## Reproduction

For a procedure definition:

```pascal
procedure TMyClass.Method;
begin
end;
```

- **Before fix**: Range is `{start: 13:0, end: 15:3}` (points to the semicolon)
- **Expected**: Range should be `{start: 13:0, end: 15:4}` (after the semicolon)

When using a half-open interval `[start, end)`, the fix before only includes up to but not including the semicolon.

## Solution

Modified `TSymbolExtractor.AddSymbol` to increment `EndPos.X` by 1, making it point to the position after the last character:

```pascal
// Fix for LSP Range specification: end position must be exclusive
// Move EndPos one position forward to make it exclusive
if (EndPos.Code <> nil) and (EndPos.Y > 0) and (EndPos.Y <= EndPos.Code.LineCount) then
  begin
    LineText := EndPos.Code.GetLine(EndPos.Y - 1, false);
    // X is 1-based, so X <= Length means we're within the line
    if EndPos.X <= Length(LineText) then
      Inc(EndPos.X)
    else
      begin
        // Move to next line if already past end of current line
        Inc(EndPos.Y);
        EndPos.X := 1;
      end;
  end;
```

**Key implementation details:**
- `TCodeXYPosition` uses 1-based indexing (converted to 0-based for LSP by subtracting 1)
- Handles line boundaries correctly (moves to next line when at line end)
- Preserves existing behavior for all other symbol operations

## Verification

After the fix, symbol ranges are correctly returned:

```json
{
  "range": {
    "start": {"line": 13, "character": 0},
    "end": {"line": 15, "character": 4}
  }
}
```

Now `replace_symbol_body` and similar operations correctly include the entire symbol definition including trailing semicolons.

## Impact

- All symbol ranges returned via `documentSymbol`
- Edit operations that depend on symbol ranges (e.g., `replace_symbol_body`)

## Testing

Tested with a Pascal procedure definition and verified:
- The `end` position now points after the semicolon (15:4 instead of 15:3)
- Symbol replacement operations no longer leave duplicate semicolons
- Line boundary handling works correctly