### PR TITLE
Exclude workspace folders settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,13 +102,6 @@ minimalisticCompletions
 showSyntaxErrors
 ```
 
-### TODO:
-
- - Optional properties are not implemented so the JSON payloads are bloated.
- - `documentHighlight` should select the begin/end keywords only.
- - `textDocument/codeAction`
-- `DocumentSymbol`class for document symbols
-
 ## Clients
 
 ### Emacs

--- a/src/serverprotocol/PasLS.General.pas
+++ b/src/serverprotocol/PasLS.General.pas
@@ -58,15 +58,16 @@ Type
   private
     function CheckProgramSetting: Boolean;
     procedure CollectWorkSpacePaths(WorkspaceFolders: TWorkspaceFolderItems;
-      aPaths: TStrings);
+      aPaths: TStrings; ExcludeFolders: TStrings);
     procedure DoLog(const Msg: String);
     procedure DoLog(const Fmt: String; const args: array of const);
     procedure DoLog(const Msg: String; aBool: Boolean);
     Function IsPasExt(Const aExtension : String) : Boolean;
+    function IsPathExcluded(const aPath: String; ExcludeFolders: TStrings): Boolean;
     procedure SetFPCPaths(Paths, Opts: TStrings; AsUnitPath, asIncludePath: Boolean);
     procedure SetPlatformDefaults(CodeToolsOptions : TCodeToolsOptions);
     procedure ApplyConfigSettings(CodeToolsOptions: TCodeToolsOptions);
-    procedure FindPascalSourceDirectories(RootPath: String; Results: TStrings);
+    procedure FindPascalSourceDirectories(RootPath: String; Results: TStrings; ExcludeFolders: TStrings);
     Procedure ShowConfigStatus(Params : TInitializeParams; CodeToolsOptions: TCodeToolsOptions);
   Public
     function Process(var Params : TLSPInitializeParams): TInitializeResult; override;
@@ -191,20 +192,54 @@ begin
   Transport.SendDiagnostic(Msg+BoolToStr(aBool,'True','False'));
 end;
 
+function TInitialize.IsPathExcluded(const aPath: String; ExcludeFolders: TStrings): Boolean;
+var
+  ExcludePath: String;
+  NormalizedPath: String;
+  NormalizedExclude: String;
+begin
+  Result := False;
+  if (ExcludeFolders = nil) or (ExcludeFolders.Count = 0) then
+    Exit;
 
-procedure TInitialize.FindPascalSourceDirectories(RootPath: String; Results: TStrings);
+  NormalizedPath := ExcludeTrailingPathDelimiter(aPath);
+
+  for ExcludePath in ExcludeFolders do
+    begin
+      NormalizedExclude := ExcludeTrailingPathDelimiter(ExcludePath);
+      // Check if the path starts with the excluded path
+      if (Pos(NormalizedExclude, NormalizedPath) = 1) then
+        begin
+          Result := True;
+          Exit;
+        end;
+    end;
+end;
+
+
+procedure TInitialize.FindPascalSourceDirectories(RootPath: String; Results: TStrings; ExcludeFolders: TStrings);
 
 var
   Info : TSearchRec;
   havePas : Boolean;
+  SubDirPath: String;
 
 begin
+  // Skip this directory if it's excluded
+  if IsPathExcluded(RootPath, ExcludeFolders) then
+    Exit;
+
   havePas:=False;
   If FindFirst(RootPath+AllFilesMask,faAnyFile,Info)=0 then
     try
       Repeat
         if ((Info.Attr and faDirectory)<>0) and Not ((Info.Name='.') or (Info.Name='..')) then
-          FindPascalSourceDirectories(IncludeTrailingPathDelimiter(RootPath+Info.Name),Results);
+          begin
+            SubDirPath := IncludeTrailingPathDelimiter(RootPath+Info.Name);
+            // Only recurse if the subdirectory is not excluded
+            if not IsPathExcluded(SubDirPath, ExcludeFolders) then
+              FindPascalSourceDirectories(SubDirPath, Results, ExcludeFolders);
+          end;
         if IsPasExt(ExtractFileExt(Info.Name)) then
           HavePas:=True;
       until (FindNext(Info)<>0);
@@ -216,14 +251,14 @@ begin
       Results.Add(RootPath);
 end;
 
-procedure TInitialize.CollectWorkSpacePaths(WorkspaceFolders : TWorkspaceFolderItems; aPaths : TStrings);
+procedure TInitialize.CollectWorkSpacePaths(WorkspaceFolders : TWorkspaceFolderItems; aPaths : TStrings; ExcludeFolders: TStrings);
 
 Var
   Item: TCollectionItem;
 
 begin
   for Item in workspaceFolders do
-    FindPascalSourceDirectories(IncludeTrailingPathDelimiter(UriToPath(TWorkspaceFolder(Item).uri)), aPaths);
+    FindPascalSourceDirectories(IncludeTrailingPathDelimiter(UriToPath(TWorkspaceFolder(Item).uri)), aPaths, ExcludeFolders);
 end;
 
 
@@ -408,7 +443,7 @@ begin
     if ServerSettings.includeWorkspaceFoldersAsUnitPaths or
        ServerSettings.includeWorkspaceFoldersAsIncludePaths then
       begin
-        CollectWorkSpacePaths(Params.workspaceFolders,Paths);
+        CollectWorkSpacePaths(Params.workspaceFolders, Paths, ServerSettings.excludeWorkspaceFolders);
       end;
     // Add the in order specified
     Paths.Sorted:=False;

--- a/src/serverprotocol/PasLS.Settings.pas
+++ b/src/serverprotocol/PasLS.Settings.pas
@@ -48,11 +48,13 @@ type
     fProgram: String;
     fSymbolDatabase: String;
     fFPCOptions: TStrings;
+    fExcludeWorkspaceFolders: TStrings;
     fCodeToolsConfig: String;
     fMaximumCompletions: Integer;
     fOverloadPolicy: TOverloadPolicy;
     fConfig: String;
     procedure SetFPCOptions(AValue: TStrings);
+    procedure SetExcludeWorkspaceFolders(AValue: TStrings);
   published
     // Path to the main program file for resolving references
     // if not available the path of the current document will be used
@@ -77,6 +79,8 @@ type
     property includeWorkspaceFoldersAsUnitPaths: Boolean read fBooleans[2] write fBooleans[2];
     // workspaces folders will be added to include paths (i.e. -Fi)
     property includeWorkspaceFoldersAsIncludePaths: Boolean read fBooleans[3] write fBooleans[3];
+    // workspace folder paths to exclude from workspace path collection
+    property excludeWorkspaceFolders: TStrings read fExcludeWorkspaceFolders write SetExcludeWorkspaceFolders;
     // syntax will be checked when file opens or saves
     property checkSyntax: Boolean read fBooleans[4] write fBooleans[4];
     // syntax errors will be published as diagnostics
@@ -222,6 +226,7 @@ begin
     fProgram:=Src.fProgram;;
     SymbolDatabase:=Src.SymbolDatabase;
     FPCOptions:=Src.fpcOptions;
+    ExcludeWorkspaceFolders:=Src.ExcludeWorkspaceFolders;
     CodeToolsConfig:=Src.CodeToolsConfig;
     MaximumCompletions:=Src.MaximumCompletions;
     OverloadPolicy:=Src.OverloadPolicy;
@@ -237,6 +242,12 @@ begin
   fFPCOptions.Assign(AValue);
 end;
 
+procedure TServerSettings.SetExcludeWorkspaceFolders(AValue: TStrings);
+begin
+  if fExcludeWorkspaceFolders=AValue then Exit;
+  fExcludeWorkspaceFolders.Assign(AValue);
+end;
+
 function TServerSettings.CanProvideWorkspaceSymbols: boolean;
 begin
   result := workspaceSymbols and 
@@ -249,6 +260,7 @@ begin
   inherited;
 
   fFPCOptions := TStringList.Create;
+  fExcludeWorkspaceFolders := TStringList.Create;
 
   // default settings
   symbolDatabase := '';
@@ -273,6 +285,7 @@ end;
 destructor TServerSettings.Destroy;
 begin
   FreeAndNil(fFPCOptions);
+  FreeAndNil(fExcludeWorkspaceFolders);
   inherited Destroy;
 end;
 


### PR DESCRIPTION
  Users can now configure the language server with an array of paths to exclude from workspace scanning. For example:

  {
    "excludeWorkspaceFolders": [
      "/path/to/workspace/node_modules",
      "/path/to/workspace/vendor"
    ]
  }

 Any directory that starts with an excluded path will be skipped during the recursive Pascal source directory search, preventing those paths from being added to the FPC unit paths (-Fu) and include paths (-Fi).