### PR TITLE
Fix: Access violation when moving/renaming files

### DIFF
--- a/src/serverprotocol/PasLS.Symbols.pas
+++ b/src/serverprotocol/PasLS.Symbols.pas
@@ -148,8 +148,7 @@ type
     fDatabase: TSymbolDatabase;
 
     function Load(Path: String): TCodeBuffer;
-    procedure RemoveFile(FileName: String);
-    procedure AddError(Message: String); 
+    procedure AddError(Message: String);
     function GetEntry(Code: TCodeBuffer): TSymbolTableEntry;
     function GetDatabase: TSymbolDatabase;
     procedure setTransport(AValue: TMessageTransport);
@@ -176,6 +175,10 @@ type
     procedure Reload(Path: String; Always: Boolean = false); overload;
     procedure Scan(Path: String; SearchSubDirs: Boolean);
     procedure FileModified(Code: TCodeBuffer);
+
+    { File Management }
+    procedure RemoveFile(FileName: String);
+
     Property Transport : TMessageTransport Read fTransport Write setTransport;
   end;
 
@@ -341,7 +344,7 @@ procedure TSymbolTableEntry.Clear;
 begin
   Modified := false;
   Symbols.Clear;
-  if SymbolManager.Database <> nil then
+  if (SymbolManager.Database <> nil) and (Code <> nil) then
     SymbolManager.Database.ClearSymbols(Code.FileName);
 end;
 
@@ -988,10 +991,20 @@ end;
 procedure TSymbolManager.RemoveFile(FileName: String);
 var
   Index: integer;
+  Entry: TSymbolTableEntry;
 begin
-  Index := SymbolTable.FindIndexOf(FileName);
-  if Index <> -1 then
-    SymbolTable.Delete(Index);
+  Entry := TSymbolTableEntry(SymbolTable.Find(FileName));
+  if Entry <> nil then
+  begin
+    // Clear symbols from database if enabled
+    if (Database <> nil) and (Entry.Code <> nil) then
+      Database.ClearSymbols(Entry.Code.FileName);
+
+    // Remove entry from in-memory symbol table
+    Index := SymbolTable.FindIndexOf(FileName);
+    if Index <> -1 then
+      SymbolTable.Delete(Index);
+  end;
 end;
 
 function TSymbolManager.FindWorkspaceSymbols(Query: String): TJSONSerializedArray;
@@ -1147,6 +1160,13 @@ begin
     begin
       Entry := TSymbolTableEntry.Create(Code);
       SymbolTable.Add(Key, Entry);
+    end
+  else if Entry.Code <> Code then
+    begin
+      // Update Entry.Code to point to the new buffer
+      // This handles the case when a file is moved/renamed:
+      // the filename (key) is the same but the Code buffer is different
+      Entry.Code := Code;
     end;
   result := Entry;
 end;

--- a/src/serverprotocol/PasLS.Synchronization.pas
+++ b/src/serverprotocol/PasLS.Synchronization.pas
@@ -24,7 +24,7 @@ unit PasLS.Synchronization;
 interface
 
 uses
-  Classes, DateUtils,
+  Classes, SysUtils, DateUtils,
   CodeToolManager, CodeCache,
   LSP.BaseTypes, LSP.Base, LSP.Basic, PasLS.Symbols, LSP.Synchronization;
 
@@ -100,14 +100,17 @@ end;
 { TDidCloseTextDocument }
 
 procedure TDidCloseTextDocument.Process(var Params : TDidCloseTextDocumentParams);
-
-
-begin with Params do
+var
+  FileName: String;
+begin
+  with Params do
   begin
-    // URI := ParseURI(textDocument.uri);
-    // TODO: clear errors
-    // TODO: if the file was manually loaded (i.e. not in search paths)
-    // then we may want to remove it from the symbol table so it doesn't cause clutter
+    // Clean up symbol table entry and database records when file is closed
+    if SymbolManager <> nil then
+    begin
+      FileName := ExtractFileName(textDocument.LocalPath);
+      SymbolManager.RemoveFile(FileName);
+    end;
   end;
 end;
 
@@ -133,13 +136,12 @@ end;
 
 procedure TDidOpenTextDocument.Process(var Params : TDidOpenTextDocumentParams);
 var
-
   Path: String;
   Code: TCodeBuffer;
-begin with Params do
+begin
+  with Params do
   begin
     Path := textDocument.LocalPath;
-
     Code := CodeToolBoss.FindFile(Path);
     if Code <> nil then
       Code.Source := textDocument.text;
@@ -148,12 +150,10 @@ begin with Params do
     // it need to be loaded from disk
     if Code = nil then
       Code := CodeToolBoss.LoadFile(Path, False, False);
-      
-    DiagnosticsHandler.CheckSyntax(Transport,Code);
 
+    DiagnosticsHandler.CheckSyntax(Transport, Code);
     CheckInactiveRegions(Transport, Code, textDocument.uri);
-    //if SymbolManager <> nil then
-    //  SymbolManager.FileModified(Code);
+
     if SymbolManager <> nil then
       SymbolManager.Reload(Code, True);
   end;


### PR DESCRIPTION
## Summary

- Fix AV caused by stale TCodeBuffer reference when files are moved/renamed
- GetEntry now updates Entry.Code when the same filename key exists but buffer differs
- Added proper cleanup in TDidCloseTextDocument.Process

## Reproduction steps (before fix)

1. Open a Pascal file (e.g., `file.pas`) in VS Code
2. Move it to another directory within the project
3. VS Code shows the file as "deleted" and closes it
4. Reopen the file from its new location
5. AV error appears in VS Code Output panel

## Test plan

- [ ] Follow reproduction steps above
- [ ] Verify no Access Violation occurs
- [ ] Verify LSP features (hover, go-to-definition) still work on the moved file