### PR TITLE
Print required server settings with -h

### DIFF
--- a/src/serverprotocol/PasLS.Settings.pas
+++ b/src/serverprotocol/PasLS.Settings.pas
@@ -99,13 +99,13 @@ type
     property config: String read fConfig write fConfig;
     // Check inactive regions
     property checkInactiveRegions : Boolean read fBooleans[11] write fBooleans[11];
-
-    function CanProvideWorkspaceSymbols: boolean;
   public
     constructor Create; override;
     Destructor Destroy; override;
     procedure ReplaceMacros(Macros: TMacroMap);
     Procedure Assign(aSource : TPersistent); override;
+    function CanProvideWorkspaceSymbols: boolean;
+    class function GetPropertyDescription(const PropName: String): String;
   end;
 
 
@@ -250,9 +250,37 @@ end;
 
 function TServerSettings.CanProvideWorkspaceSymbols: boolean;
 begin
-  result := workspaceSymbols and 
-            (symbolDatabase <> '') and 
+  result := workspaceSymbols and
+            (symbolDatabase <> '') and
             FileExists(ExpandFileName(symbolDatabase));
+end;
+
+class function TServerSettings.GetPropertyDescription(const PropName: String): String;
+begin
+  case PropName of
+    'program': Result := 'Path to the main program file for resolving references';
+    'symbolDatabase': Result := 'Path to SQLite3 database for symbols';
+    'fpcOptions': Result := 'FPC compiler options (passed to Code Tools)';
+    'codeToolsConfig': Result := 'Optional codetools.config file to load settings from';
+    'maximumCompletions': Result := 'Maximum number of completion items to be returned';
+    'overloadPolicy': Result := 'Policy which determines how overloaded document symbols are displayed';
+    'insertCompletionsAsSnippets': Result := 'Procedure completions with parameters are inserted as snippets';
+    'insertCompletionProcedureBrackets': Result := 'Procedure completions with parameters insert empty brackets';
+    'includeWorkspaceFoldersAsUnitPaths': Result := 'Workspace folders will be added to unit paths (i.e. -Fu)';
+    'includeWorkspaceFoldersAsIncludePaths': Result := 'Workspace folders will be added to include paths (i.e. -Fi)';
+    'excludeWorkspaceFolders': Result := 'Workspace folder paths to exclude from workspace path collection';
+    'checkSyntax': Result := 'Syntax will be checked when file opens or saves';
+    'publishDiagnostics': Result := 'Syntax errors will be published as diagnostics';
+    'workspaceSymbols': Result := 'Enable workspace symbols';
+    'documentSymbols': Result := 'Enable document symbols';
+    'minimalisticCompletions': Result := 'Completions contain a minimal amount of extra information';
+    'showSyntaxErrors': Result := 'Syntax errors as shown in the UI with ''window/showMessage''';
+    'ignoreTextCompletions': Result := 'Ignores completion items like "begin" and "var"';
+    'config': Result := 'Config file or directory to read settings from';
+    'checkInactiveRegions': Result := 'Check inactive regions';
+    else
+      Result := '';
+  end;
 end;
 
 constructor TServerSettings.Create;

--- a/src/standard/pasls.lpr
+++ b/src/standard/pasls.lpr
@@ -25,7 +25,7 @@ program pasls;
 uses
   { RTL }
 
-  SysUtils, Classes, FPJson, JSONParser, JSONScanner,
+  SysUtils, Classes, FPJson, JSONParser, JSONScanner, TypInfo,
   { Protocol }
   PasLS.AllCommands, PasLS.Settings,
   LSP.Base, LSP.Basic, PasLS.TextLoop, PasLS.LSConfig;
@@ -84,6 +84,74 @@ begin
     end;
 end;
 
+Procedure PrintInitializationOptions;
+var
+  Settings: TServerSettings;
+  PropList: PPropList;
+  PropCount, I: Integer;
+  PropInfo: PPropInfo;
+  PropName, TypeName, DefaultValue, Description: String;
+begin
+  Settings := TServerSettings.Create;
+  try
+    PropCount := GetPropList(Settings, PropList);
+    try
+      writeln('Initialization Options:');
+      for I := 0 to PropCount - 1 do
+        begin
+          PropInfo := PropList^[I];
+          PropName := PropInfo^.Name;
+          Description := TServerSettings.GetPropertyDescription(PropName);
+
+          // Get property type name
+          case PropInfo^.PropType^.Kind of
+            tkInteger: TypeName := 'integer';
+            tkBool: TypeName := 'boolean';
+            tkAString, tkLString, tkUString: TypeName := 'string';
+            tkClass:
+              if PropInfo^.PropType^.Name = 'TStrings' then
+                TypeName := 'array'
+              else
+                TypeName := PropInfo^.PropType^.Name;
+            tkEnumeration: TypeName := 'enumeration';
+            else
+              TypeName := '';
+          end;
+
+          // Get default value
+          DefaultValue := '';
+          case PropInfo^.PropType^.Kind of
+            tkInteger:
+              DefaultValue := IntToStr(GetOrdProp(Settings, PropInfo));
+            tkBool:
+              DefaultValue := BoolToStr(GetOrdProp(Settings, PropInfo) <> 0, 'true', 'false');
+            tkAString, tkLString, tkUString:
+              begin
+                DefaultValue := GetStrProp(Settings, PropInfo);
+                if DefaultValue <> '' then
+                  DefaultValue := '"' + DefaultValue + '"';
+              end;
+            tkEnumeration:
+              DefaultValue := IntToStr(GetOrdProp(Settings, PropInfo));
+          end;
+
+          // Format output
+          write('  ▶ ', PropName);
+          if Description <> '' then
+            write(': ', Description);
+          write(' (', TypeName);
+          if DefaultValue <> '' then
+            write(', default: ', DefaultValue);
+          writeln(')');
+        end;
+    finally
+      FreeMem(PropList);
+    end;
+  finally
+    Settings.Free;
+  end;
+end;
+
 var
   aTransport: TLSPTextTransport;
   aContext: TLSPLogContext;
@@ -103,6 +171,17 @@ begin
   if ParamStr(1) = '-h' then
     begin
     writeln('Pascal Language Server [',{$INCLUDE %DATE%},']');
+    writeln;
+    writeln('Environment Variables:');
+    writeln('  PP           - Path to Free Pascal compiler executable');
+    writeln('  FPCDIR       - Path to FPC source directory');
+    writeln('  LAZARUSDIR   - Path to Lazarus source directory');
+    writeln('  FPCTARGET    - Target OS (e.g., darwin, linux, win64)');
+    writeln('  FPCTARGETCPU - Target CPU (e.g., x86_64, aarch64)');
+    writeln;
+    PrintInitializationOptions;
+    writeln;
+    writeln('For more information: https://github.com/genericptr/pascal-language-server');
     Halt;
     end;
   aContext := nil;


### PR DESCRIPTION
`pasls -h` now prints the required server settings so there is an official way to know which settings are required for the server you're using.

```
Pascal Language Server [2025/12/28]

Environment Variables:
  PP           - Path to Free Pascal compiler executable
  FPCDIR       - Path to FPC source directory
  LAZARUSDIR   - Path to Lazarus source directory
  FPCTARGET    - Target OS (e.g., darwin, linux, win64)
  FPCTARGETCPU - Target CPU (e.g., x86_64, aarch64)

Initialization Options:
  ▶ program: Path to the main program file for resolving references (string)
  ▶ symbolDatabase: Path to SQLite3 database for symbols (string)
  ▶ fpcOptions: FPC compiler options (passed to Code Tools) (array)
  ▶ codeToolsConfig: Optional codetools.config file to load settings from (string)
  ▶ maximumCompletions: Maximum number of completion items to be returned (integer, default: 200)
  ▶ overloadPolicy: Policy which determines how overloaded document symbols are displayed (enumeration, default: 3)
  ▶ insertCompletionsAsSnippets: Procedure completions with parameters are inserted as snippets (boolean, default: true)
  ▶ insertCompletionProcedureBrackets: Procedure completions with parameters insert empty brackets (boolean, default: false)
  ▶ includeWorkspaceFoldersAsUnitPaths: Workspace folders will be added to unit paths (i.e. -Fu) (boolean, default: true)
  ▶ includeWorkspaceFoldersAsIncludePaths: Workspace folders will be added to include paths (i.e. -Fi) (boolean, default: true)
  ▶ excludeWorkspaceFolders: Workspace folder paths to exclude from workspace path collection (array)
  ▶ checkSyntax: Syntax will be checked when file opens or saves (boolean, default: false)
  ▶ publishDiagnostics: Syntax errors will be published as diagnostics (boolean, default: false)
  ▶ workspaceSymbols: Enable workspace symbols (boolean, default: true)
  ▶ documentSymbols: Enable document symbols (boolean, default: true)
  ▶ minimalisticCompletions: Completions contain a minimal amount of extra information (boolean, default: false)
  ▶ showSyntaxErrors: Syntax errors as shown in the UI with 'window/showMessage' (boolean, default: false)
  ▶ ignoreTextCompletions: Ignores completion items like "begin" and "var" (boolean, default: true)
  ▶ config: Config file or directory to read settings from (string)
  ▶ checkInactiveRegions: Check inactive regions (boolean, default: false)

For more information: https://github.com/genericptr/pascal-language-server
```