### PR TITLE
Fix EInOutError when printing help with Unicode characters on Windows

### DIFF
--- a/src/standard/pasls.lpr
+++ b/src/standard/pasls.lpr
@@ -23,8 +23,10 @@ program pasls;
 {$mode objfpc}{$H+}
 
 uses
+  {$IFDEF WINDOWS}
+  Windows,
+  {$ENDIF}
   { RTL }
-
   SysUtils, Classes, FPJson, JSONParser, JSONScanner, TypInfo,
   { Protocol }
   PasLS.AllCommands, PasLS.Settings,
@@ -92,6 +94,9 @@ var
   PropInfo: PPropInfo;
   PropName, TypeName, DefaultValue, Description: String;
 begin
+  {$IFDEF WINDOWS}
+  SetConsoleOutputCP(CP_UTF8);  // 65001
+  {$ENDIF}
   Settings := TServerSettings.Create;
   try
     PropCount := GetPropList(Settings, PropList);


### PR DESCRIPTION
## Summary

- Fix `EInOutError: Disk Full` crash when running `pasls -h` on Windows console
- Root cause: Unicode bullet character (U+25B6) cannot be encoded in Windows default codepage
- Solution: Set console output codepage to UTF-8 (65001) before printing help text

## Test plan

- [ ] Run `pasls.exe -h` on Windows console (cmd.exe or PowerShell)
- [ ] Verify help text displays correctly without crash
- [ ] Verify Unicode bullet characters render properly