### PR TITLE
Fix/non utf8

### DIFF
--- a/src/protocol/PasLS.SocketDispatcher.pas
+++ b/src/protocol/PasLS.SocketDispatcher.pas
@@ -56,7 +56,7 @@ Type
   TLSPFrame = Packed Record
   private
     function GetMessageType: TLSPProtocolMessageType;
-    function GetPayloadString: UTF8String;
+    function GetPayloadString: String;
     procedure SetMessageType(AValue: TLSPProtocolMessageType);
   public
     Version : Byte;
@@ -65,7 +65,7 @@ Type
     PayloadLen : cardinal; // In network order
     PayLoad : TBytes;
     Property MessageType : TLSPProtocolMessageType Read GetMessageType Write SetMessageType;
-    Property PayloadString : UTF8String Read GetPayloadString;
+    Property PayloadString : String Read GetPayloadString;
   end;
 
   ELSPSocket = Class(Exception);
@@ -234,9 +234,16 @@ begin
   Result:=TLSPProtocolMessageType(MsgType);
 end;
 
-function TLSPFrame.GetPayloadString: UTF8String;
+function TLSPFrame.GetPayloadString: String;
+var
+  Len: SizeInt;
 begin
-  Result:=TEncoding.UTF8.GetAnsiString(Payload);
+  Len:=Length(Payload);
+  if Len=0 then
+    exit('');
+  SetLength(Result, Len);
+  Move(Payload[0], PAnsiChar(RawByteString(Result))^, Len);
+  SetCodePage(RawByteString(Result), CP_UTF8, False);
 end;
 
 procedure TLSPFrame.SetMessageType(AValue: TLSPProtocolMessageType);

--- a/src/proxy/paslsproxy.lpr
+++ b/src/proxy/paslsproxy.lpr
@@ -222,6 +222,9 @@ begin
     end;
   if not ParseOptions(lParams) then
     exit;
+  SetTextCodePage(output, CP_UTF8);
+  SetTextCodePage(StdErr, CP_UTF8);
+
   aTrans:=SetupTransport;
   try
     aDisp:=TLSPClientSocketDispatcher.Create(aTrans);

--- a/src/serverprotocol/PasLS.Command.CompleteCode.pas
+++ b/src/serverprotocol/PasLS.Command.CompleteCode.pas
@@ -76,6 +76,11 @@ begin
 
   Transport.SendDiagnostic(' ✅ Sucesss NewX: %d NewY: %d NewTopLine: %d BlockTopLine: %d BlockBottomLine: %d', [NewX, NewY, NewTopLine, BlockTopLine, BlockBottomLine]);
   //procedure AbsoluteToLineCol(Position: integer; out Line, Column: integer);
+  if Code.Count< 1 then
+    begin
+    Transport.SendDiagnostic( '🔴 CompleteCode Resulting Code is empty');
+    Exit;
+    end;
   With Code[Code.Count - 1] do
     Transport.SendDiagnostic( 'Position: %d : %d - Length: %d', [Position, Code.GetLineStart(Position),Len]);
   // TODO: we need to get character offsets and get the text out of the source

--- a/src/serverprotocol/PasLS.Synchronization.pas
+++ b/src/serverprotocol/PasLS.Synchronization.pas
@@ -143,15 +143,22 @@ begin
   begin
     Path := textDocument.LocalPath;
     Code := CodeToolBoss.FindFile(Path);
-    if Code <> nil then
-      Code.Source := textDocument.text;
 
     // the file was not found in search paths so
     // it need to be loaded from disk
     if Code = nil then
       Code := CodeToolBoss.LoadFile(Path, False, False);
+    
+    //rename file will failue ,need CreateFile ,It not create file in disk.(s)
+    if Code = nil then
+      begin
+        Code :=CodeToolBoss.CreateFile(Path);
+      end;
+    //allways update the source from the opened document
+    Code.Source:=textDocument.text;
 
     DiagnosticsHandler.CheckSyntax(Transport, Code);
+  
     CheckInactiveRegions(Transport, Code, textDocument.uri);
 
     if SymbolManager <> nil then

--- a/src/standard/pasls.lpr
+++ b/src/standard/pasls.lpr
@@ -190,6 +190,8 @@ begin
     Halt;
     end;
   aContext := nil;
+  SetTextCodePage(output, CP_UTF8);
+  SetTextCodePage(StdErr, CP_UTF8);
   aCfg := TLSPServerConfig.Create;
   try
     RegisterAllCommands;


### PR DESCRIPTION
When the source code is GB2312, TEncoding.UTF8.GetAnsiString will cause encoding errors.