### PR TITLE
Fix: Av Error when code is null in TCompletion.Process

### DIFF
--- a/src/serverprotocol/PasLS.Completion.pas
+++ b/src/serverprotocol/PasLS.Completion.pas
@@ -179,6 +179,17 @@ var
 begin with Params do
   begin
     Code := CodeToolBoss.FindFile(textDocument.LocalPath);
+    if Code=nil then
+       Code:=CodeToolBoss.LoadFile(textDocument.LocalPath,true,false);
+
+    if Code=nil then
+       begin
+         Result := TCompletionList.Create;
+         Result.isIncomplete:=false;
+         exit;
+       end;
+
+
     X := position.character;
     Y := position.line;
     Line := Code.GetLine(Y);

--- a/src/serverprotocol/PasLS.Settings.pas
+++ b/src/serverprotocol/PasLS.Settings.pas
@@ -303,6 +303,7 @@ begin
   ignoreTextCompletions := true;
   workspaceSymbols := true;
   minimalisticCompletions := false;
+  checkInactiveRegions := true;
   
   // errors/diagnostics
   checkSyntax := false;


### PR DESCRIPTION
Fix: AV Error when code is null in TCompletion.Process
Enable checkInactiveRegions