### PR TITLE
includeFieldsInSymbols option for symbol list

### DIFF
--- a/src/serverprotocol/PasLS.Settings.pas
+++ b/src/serverprotocol/PasLS.Settings.pas
@@ -103,6 +103,8 @@ type
     property config: String read fConfig write fConfig;
     // Check inactive regions
     property checkInactiveRegions : Boolean read fBooleans[11] write fBooleans[11];
+    // Include properties and fields in document symbols
+    property includeFieldsInSymbols : Boolean read fBooleans[12] write fBooleans[12];
     // Client profile feature overrides
     property clientProfileEnableFeatures: TStrings
       read fClientProfileEnableFeatures write SetClientProfileEnableFeatures;
@@ -301,6 +303,7 @@ begin
     'ignoreTextCompletions': Result := 'Ignores completion items like "begin" and "var"';
     'config': Result := 'Config file or directory to read settings from';
     'checkInactiveRegions': Result := 'Check inactive regions';
+    'includeFieldsInSymbols': Result := 'Include properties and fields in document symbols';
     'clientProfileEnableFeatures': Result := 'List of features to force-enable regardless of client profile';
     'clientProfileDisableFeatures': Result := 'List of features to force-disable regardless of client profile';
     else
@@ -330,7 +333,8 @@ begin
   ignoreTextCompletions := true;
   workspaceSymbols := true;
   minimalisticCompletions := false;
-  
+  includeFieldsInSymbols := false;
+
   // errors/diagnostics
   checkSyntax := false;
   publishDiagnostics := false;

--- a/src/serverprotocol/PasLS.Symbols.pas
+++ b/src/serverprotocol/PasLS.Symbols.pas
@@ -164,7 +164,7 @@ type
     function ExtractProcedure(ParentNode, Node: TCodeTreeNode):TSymbol;
     procedure ProcessNestedFunctions(Node: TCodeTreeNode; ParentSymbol: TDocumentSymbolEx; const ParentPath: String);
     procedure ExtractTypeDefinition(TypeDefNode, Node: TCodeTreeNode); 
-    procedure ExtractObjCClassMethods(ClassNode, Node: TCodeTreeNode);
+    procedure ExtractSymbols(ClassNode, Node: TCodeTreeNode);
   public
     constructor Create(_Entry: TSymbolTableEntry; _Code: TCodeBuffer; _Tool: TCodeTool);
     destructor Destroy; override;
@@ -1007,7 +1007,7 @@ begin
   Result := Entry.AddSymbol(Name, Kind, CodePos.Code.FileName, CodePos.Y, CodePos.X, EndPos.Y,EndPos.X);
 end;
 
-procedure TSymbolExtractor.ExtractObjCClassMethods(ClassNode, Node: TCodeTreeNode);
+procedure TSymbolExtractor.ExtractSymbols(ClassNode, Node: TCodeTreeNode);
 var
   Child: TCodeTreeNode;
   ExternalClass: boolean = false;
@@ -1041,36 +1041,35 @@ begin
             Builder.AddMethod(Node, TypeName, Tool.ExtractProcName(Node, []));
           end;
         ctnProperty:
-          begin
-            // For property, skip the "property" keyword to get the actual property name
-            Tool.MoveCursorToCleanPos(Node.StartPos);
-            Tool.ReadNextAtom; // Skip "property" keyword
-            Tool.ReadNextAtom; // Move to property name
-            TypeName := GetIdentifierAtPos(Tool, ClassNode.StartPos, true, true);
-            // Extract property name from current atom
-            PropertyName := Copy(Tool.Scanner.CleanedSrc, Tool.CurPos.StartPos,
-                                 Tool.CurPos.EndPos - Tool.CurPos.StartPos);
-            Builder.AddProperty(Node, TypeName, PropertyName);
-          end;
+          if ServerSettings.includeFieldsInSymbols then
+            begin
+              // For property, skip the "property" keyword to get the actual property name
+              Tool.MoveCursorToCleanPos(Node.StartPos);
+              Tool.ReadNextAtom; // Skip "property" keyword
+              Tool.ReadNextAtom; // Move to property name
+              TypeName := GetIdentifierAtPos(Tool, ClassNode.StartPos, true, true);
+              // Extract property name from current atom
+              PropertyName := Copy(Tool.Scanner.CleanedSrc, Tool.CurPos.StartPos,
+                                   Tool.CurPos.EndPos - Tool.CurPos.StartPos);
+              Builder.AddProperty(Node, TypeName, PropertyName);
+            end;
         ctnVarDefinition:
-          begin
-            // Extract field (class member variable)
-            TypeName := GetIdentifierAtPos(Tool, ClassNode.StartPos, true, true);
-            // For field, extract identifier without the colon
-            FieldName := GetIdentifierAtPos(Tool, Node.StartPos, true, true);
-            // Remove trailing colon if present
-            i := Pos(':', FieldName);
-            if i > 0 then
-              FieldName := Copy(FieldName, 1, i - 1);
-            Builder.AddField(Node, TypeName, FieldName);
-          end;
+          if ServerSettings.includeFieldsInSymbols then
+            begin
+              // Extract field (class member variable)
+              TypeName := GetIdentifierAtPos(Tool, ClassNode.StartPos, true, true);
+              // For field, extract identifier without the colon
+              FieldName := GetIdentifierAtPos(Tool, Node.StartPos, true, true);
+              // Remove trailing colon if present
+              i := Pos(':', FieldName);
+              if i > 0 then
+                FieldName := Copy(FieldName, 1, i - 1);
+              Builder.AddField(Node, TypeName, FieldName);
+            end;
         ctnClassPublic,ctnClassPublished,ctnClassPrivate,ctnClassProtected,
         ctnClassRequired,ctnClassOptional:
           if ExternalClass then
             begin
-              // if the class is external then search methods
-              //if ExternalClass then
-              //  ExtractObjCClassMethods(ClassNode, Node.FirstChild);
               TypeName := GetIdentifierAtPos(Tool, ClassNode.StartPos, true, true);
               Child := Node.FirstChild;
               while Child <> nil do
@@ -1085,7 +1084,7 @@ begin
             begin
               // For regular Pascal classes, recurse into visibility sections
               Inc(IndentLevel);
-              ExtractObjCClassMethods(ClassNode, Node.FirstChild);
+              ExtractSymbols(ClassNode, Node.FirstChild);
               Dec(IndentLevel);
             end;
       end;
@@ -1137,7 +1136,7 @@ begin
             TypeName := CleanTypeName(GetIdentifierAtPos(Tool, TypeDefNode.StartPos, true, true));
             Builder.AddClass(TypeDefNode, TypeName);
             Inc(IndentLevel);
-            ExtractObjCClassMethods(TypeDefNode, Node.FirstChild);
+            ExtractSymbols(TypeDefNode, Node.FirstChild);
             Dec(IndentLevel);
           end;
         ctnObject,ctnRecordType:
@@ -1151,7 +1150,7 @@ begin
             TypeName := CleanTypeName(GetIdentifierAtPos(Tool, TypeDefNode.StartPos, true, true));
             Builder.AddClass(TypeDefNode, TypeName);
             Inc(IndentLevel);
-            ExtractObjCClassMethods(TypeDefNode, Node.FirstChild);
+            ExtractSymbols(TypeDefNode, Node.FirstChild);
             Dec(IndentLevel);
           end;
         ctnSpecialize:


### PR DESCRIPTION
Showing fields and properties of structs in the symbol list was recently added but I personally don't find this helpful and it clutters up the list for browsing. For example I don't think I ever want to jump around between private fields of classes and would prefer to just go to the class definition itself.

I put this behind a new option `includeFieldsInSymbols` and set the default to false but I'd like to hear feedback on what the default should be. @mvancanneyt  and @zen010101 what do you think about the default?

zen010101 was probably correct in showing them because the LSP supports it so this is just about the default.