### PR TITLE
feat: improve workspace/symbol reliability and fix memory leaks

### DIFF
--- a/src/serverprotocol/PasLS.General.pas
+++ b/src/serverprotocol/PasLS.General.pas
@@ -503,15 +503,15 @@ begin
         end;
 
     if Result.Capabilities.workspaceSymbolProvider then
-    begin
+      begin
       // Store workspace paths in SymbolManager for IsFileInWorkspace checks
       SymbolManager.WorkspacePaths.Clear;
       for aPath in Paths do
-      begin
+        begin
         SymbolManager.WorkspacePaths.Add(SymbolManager.NormalizePath(aPath));
         SymbolManager.Scan(aPath, false);
+        end;
       end;
-    end;
 
     CheckProgramSetting;
 

--- a/src/serverprotocol/PasLS.General.pas
+++ b/src/serverprotocol/PasLS.General.pas
@@ -503,8 +503,15 @@ begin
         end;
 
     if Result.Capabilities.workspaceSymbolProvider then
+    begin
+      // Store workspace paths in SymbolManager for IsFileInWorkspace checks
+      SymbolManager.WorkspacePaths.Clear;
       for aPath in Paths do
+      begin
+        SymbolManager.WorkspacePaths.Add(SymbolManager.NormalizePath(aPath));
         SymbolManager.Scan(aPath, false);
+      end;
+    end;
 
     CheckProgramSetting;
 

--- a/src/serverprotocol/PasLS.Settings.pas
+++ b/src/serverprotocol/PasLS.Settings.pas
@@ -273,14 +273,6 @@ end;
 
 function TServerSettings.CanProvideWorkspaceSymbols: boolean;
 begin
-  //result := workspaceSymbols and
-  //          (symbolDatabase <> '') and
-  //          FileExists(ExpandFileName(symbolDatabase));
-
-  // Fixed the format issue of CollectSerializedSymbols, returning results in
-  // the SymboleInformation[] format. As a result, the usage conditions for
-  // the workspaceSymbols function can be relaxed, allowing its use without
-  // database.
   result := workspaceSymbols;
 end;
 

--- a/src/serverprotocol/PasLS.Settings.pas
+++ b/src/serverprotocol/PasLS.Settings.pas
@@ -273,9 +273,15 @@ end;
 
 function TServerSettings.CanProvideWorkspaceSymbols: boolean;
 begin
-  result := workspaceSymbols and
-            (symbolDatabase <> '') and
-            FileExists(ExpandFileName(symbolDatabase));
+  //result := workspaceSymbols and
+  //          (symbolDatabase <> '') and
+  //          FileExists(ExpandFileName(symbolDatabase));
+
+  // Fixed the format issue of CollectSerializedSymbols, returning results in
+  // the SymboleInformation[] format. As a result, the usage conditions for
+  // the workspaceSymbols function can be relaxed, allowing its use without
+  // database.
+  result := workspaceSymbols;
 end;
 
 class function TServerSettings.GetPropertyDescription(const PropName: String): String;

--- a/src/serverprotocol/PasLS.Symbols.pas
+++ b/src/serverprotocol/PasLS.Symbols.pas
@@ -64,6 +64,7 @@ type
     Symbols: TSymbolItems;
     Code: TCodeBuffer;
     fRawJSON: String;
+    fUnloaded: Boolean;
     function GetRawJSON: String; inline;
   public
     Modified: Boolean;
@@ -76,6 +77,7 @@ type
     function RequestReload: boolean;
     function Count: integer; inline;
     property RawJSON: String read GetRawJSON;
+    property Unloaded: Boolean read fUnloaded write fUnloaded;
   end;
 
   { TSymbolBuilder }
@@ -178,6 +180,8 @@ type
     function SingleQuery(Stat: String): boolean;
     function Exec(Stat: String): boolean;
     procedure LogError(errmsg: pansichar); virtual;
+  public
+    destructor Destroy; override;
   end;
 
   { TSymbolDatabase }
@@ -203,6 +207,7 @@ type
     procedure TouchFile(Path: String);
     function FileModified(Path: String): boolean;
     procedure InsertFile(Path: String);
+    procedure RemoveFile(Path: String);
     Property Transport : TMessageTransport Read FTransport Write FTransport;
   end;
 
@@ -214,6 +219,7 @@ type
     SymbolTable: TFPHashObjectList;
     ErrorList: TStringList;
     fDatabase: TSymbolDatabase;
+    fWorkspacePaths: TStringList;
 
     function Load(Path: String): TCodeBuffer;
     procedure AddError(Message: String);
@@ -233,7 +239,7 @@ type
     { Searching }
     function FindDocumentSymbols(Path: String): TJSONSerializedArray;
     function FindWorkspaceSymbols(Query: String): TJSONSerializedArray;
-    function CollectSerializedSymbols: TJSONSerializedArray;
+    function CollectSerializedSymbols(Query: String): TJSONSerializedArray;
 
     { Errors }
     procedure ClearErrors;
@@ -246,6 +252,13 @@ type
 
     { File Management }
     procedure RemoveFile(FileName: String);
+    procedure UnloadFile(FileName: String);
+    function IsFileUnloaded(FileName: String): Boolean;
+
+    { Workspace Management }
+    property WorkspacePaths: TStringList read fWorkspacePaths;
+    function NormalizePath(const Path: String): String;
+    function IsFileInWorkspace(const FilePath: String): Boolean;
 
     Property Transport : TMessageTransport Read fTransport Write setTransport;
   end;
@@ -796,6 +809,10 @@ begin
             end;
         finally
           SerializedItems.Free;
+          // Clear Symbols to free memory if database is available
+          // (workspace/symbol will use Database.FindSymbols instead of in-memory symbols)
+          if SymbolManager.Database <> nil then
+            FEntry.Symbols.Clear;
         end;
       end;
   end;
@@ -901,7 +918,10 @@ begin
     fRawJSON := SerializedItems.AsJSON;
   Finally
     SerializedItems.Free;
-    Symbols.Clear;
+    // Clear Symbols to free memory if database is available
+    // (workspace/symbol will use Database.FindSymbols instead of in-memory symbols)
+    if SymbolManager.Database <> nil then
+      Symbols.Clear;
   end;
 end;
 
@@ -921,6 +941,8 @@ end;
 
 constructor TSymbolTableEntry.Create(_Code: TCodeBuffer);
 begin
+  inherited Create;
+  fUnloaded := False;
   Code := _Code;
   Key := ExtractFileName(Code.FileName);
   Symbols := TSymbolItems.Create;
@@ -1435,9 +1457,15 @@ begin
 end;
 
 destructor TSymbolExtractor.Destroy;
+var
+  i: Integer;
 begin
   Builder.SerializeSymbols;
   Builder.Free;
+  // Free all TSymbol objects in OverloadMap before freeing the list
+  // (TFPHashList doesn't own its items)
+  for i := 0 to OverloadMap.Count - 1 do
+    TSymbol(OverloadMap.Items[i]).Free;
   OverloadMap.Free;
   RelatedFiles.Free;
   inherited;
@@ -1471,6 +1499,13 @@ begin
   result := sqlite3_exec(database, @Stat[1], nil, nil, @errmsg) = SQLITE_OK;
   if not result then
     LogError(errmsg);
+end;
+
+destructor TSQLiteDatabase.Destroy;
+begin
+  if Database <> nil then
+    sqlite3_close(Database);
+  inherited;
 end;
 
 { TSymbolDatabase }
@@ -1622,6 +1657,19 @@ begin
   Exec(Stat);
 end;
 
+procedure TSymbolDatabase.RemoveFile(Path: String);
+var
+  Stat: String;
+begin
+  // Delete from symbols table
+  Stat := 'DELETE FROM symbols WHERE path = '''+Path+'''';
+  Exec(Stat);
+
+  // Delete from entries table (so file will be re-scanned on next open)
+  Stat := 'DELETE FROM entries WHERE path = '''+Path+'''';
+  Exec(Stat);
+end;
+
 procedure TSymbolDatabase.InsertSymbols(Collection: TSymbolItems; StartIndex, EndIndex: Integer);
 var
   Stat: String;
@@ -1733,9 +1781,9 @@ begin
   Entry := TSymbolTableEntry(SymbolTable.Find(FileName));
   if Entry <> nil then
   begin
-    // Clear symbols from database if enabled
+    // Remove file from database (both symbols and entries tables)
     if (Database <> nil) and (Entry.Code <> nil) then
-      Database.ClearSymbols(Entry.Code.FileName);
+      Database.RemoveFile(Entry.Code.FileName);
 
     // Remove entry from in-memory symbol table
     Index := SymbolTable.FindIndexOf(FileName);
@@ -1744,34 +1792,88 @@ begin
   end;
 end;
 
+procedure TSymbolManager.UnloadFile(FileName: String);
+var
+  Index: Integer;
+  Entry: TSymbolTableEntry;
+begin
+  Entry := TSymbolTableEntry(SymbolTable.Find(FileName));
+
+  // Guard: nothing to unload
+  if Entry = nil then
+    Exit;
+
+  if Database <> nil then
+  begin
+    // With database: just remove from memory, symbols stay in DB
+    Index := SymbolTable.FindIndexOf(FileName);
+    if Index <> -1 then
+      SymbolTable.Delete(Index);  // Frees TSymbolTableEntry
+  end
+  else
+  begin
+    // Without database: keep entry for workspace/symbol queries
+    // Mark as unloaded so we know the file is closed
+    Entry.Unloaded := True;
+    // Note: Entry and its Symbols remain in memory
+  end;
+end;
+
+function TSymbolManager.IsFileUnloaded(FileName: String): Boolean;
+var
+  Entry: TSymbolTableEntry;
+begin
+  Result := False;
+  Entry := TSymbolTableEntry(SymbolTable.Find(FileName));
+  if Entry <> nil then
+    Result := Entry.Unloaded;
+end;
+
 function TSymbolManager.FindWorkspaceSymbols(Query: String): TJSONSerializedArray;
 begin
   if Database <> nil then
     result := Database.FindSymbols(Query)
   else
-    result := CollectSerializedSymbols;
+    result := CollectSerializedSymbols(Query);
 end;
 
-function TSymbolManager.CollectSerializedSymbols: TJSONSerializedArray;
+function TSymbolManager.CollectSerializedSymbols(Query: String): TJSONSerializedArray;
 var
-  i : integer;
+  i, j: integer;
   Entry: TSymbolTableEntry;
+  Symbol: TSymbol;
   Contents: TLongString;
+  NeedComma: Boolean;
+  LowerQuery: String;
 begin
   Contents.Clear;
   Contents.Add('[');
+  NeedComma := False;
+  LowerQuery := LowerCase(Query);
 
+  // Collect individual Symbol.RawJSON (SymbolInformation format)
+  // instead of Entry.RawJSON (which is DocumentSymbol format in hierarchical mode)
   for i := 0 to SymbolTable.Count - 1 do
     begin
       Entry := TSymbolTableEntry(SymbolTable[i]);
-      if Entry.RawJSON <> '' then
-        if Contents.Add(Entry.RawJSON, 1, Length(Entry.RawJSON) - 2) then
-          Contents.Add(',');
+      for j := 0 to Entry.Count - 1 do
+        begin
+          Symbol := Entry.Symbols.Items[j];
+          // Filter by query (case-insensitive substring match, like database)
+          if (LowerQuery = '') or (Pos(LowerQuery, LowerCase(Symbol.Name)) > 0) then
+            begin
+              if Symbol.RawJSON <> '' then
+                begin
+                  if NeedComma then
+                    Contents.Add(',');
+                  Contents.Add(Symbol.RawJSON);
+                  NeedComma := True;
+                end;
+            end;
+        end;
     end;
-  
-  Contents.Rewind;
-  Contents.Add(']');
 
+  Contents.Add(']');
   Result := TJSONSerializedArray.Create(Contents.S);
 end;
 
@@ -1898,12 +2000,22 @@ begin
       Entry := TSymbolTableEntry.Create(Code);
       SymbolTable.Add(Key, Entry);
     end
-  else if Entry.Code <> Code then
+  else
     begin
-      // Update Entry.Code to point to the new buffer
-      // This handles the case when a file is moved/renamed:
-      // the filename (key) is the same but the Code buffer is different
-      Entry.Code := Code;
+      // Handle reopening of unloaded files
+      if Entry.Unloaded then
+      begin
+        Entry.Unloaded := False;
+        Entry.Modified := True;  // Force reload on next request
+      end;
+
+      if Entry.Code <> Code then
+      begin
+        // Update Entry.Code to point to the new buffer
+        // This handles the case when a file is moved/renamed:
+        // the filename (key) is the same but the Code buffer is different
+        Entry.Code := Code;
+      end;
     end;
   result := Entry;
 end;
@@ -1964,15 +2076,59 @@ end;
 
 constructor TSymbolManager.Create;
 begin
+  inherited Create;
   SymbolTable := TFPHashObjectList.Create(True);
   ErrorList := TStringList.Create;
+  fWorkspacePaths := TStringList.Create;
+  {$IFDEF WINDOWS}
+  fWorkspacePaths.CaseSensitive := False;
+  {$ELSE}
+  fWorkspacePaths.CaseSensitive := True;
+  {$ENDIF}
 end;
 
-destructor TSymbolManager.Destroy; 
+destructor TSymbolManager.Destroy;
 begin
+  FreeAndNil(fDatabase);
+  FreeAndNil(fWorkspacePaths);
   ErrorList.Free;
   SymbolTable.Free;
   inherited;
+end;
+
+function TSymbolManager.NormalizePath(const Path: String): String;
+begin
+  Result := ExpandFileName(Path);
+  {$IFDEF WINDOWS}
+  Result := LowerCase(Result);
+  {$ENDIF}
+  // Ensure trailing separator for directory comparison
+  Result := IncludeTrailingPathDelimiter(Result);
+end;
+
+function TSymbolManager.IsFileInWorkspace(const FilePath: String): Boolean;
+var
+  NormalizedFile: String;
+  WorkspacePath: String;
+  FileDir: String;
+  i: Integer;
+begin
+  Result := False;
+  if fWorkspacePaths.Count = 0 then
+    Exit;
+
+  // Get directory without trailing delimiter, then normalize
+  // This avoids double trailing delimiters when NormalizePath adds one
+  FileDir := ExcludeTrailingPathDelimiter(ExtractFilePath(FilePath));
+  NormalizedFile := NormalizePath(FileDir);
+
+  for i := 0 to fWorkspacePaths.Count - 1 do
+  begin
+    WorkspacePath := fWorkspacePaths[i];
+    // Check if file path starts with workspace path
+    if Copy(NormalizedFile, 1, Length(WorkspacePath)) = WorkspacePath then
+      Exit(True);
+  end;
 end;
 
 finalization

--- a/src/serverprotocol/PasLS.Symbols.pas
+++ b/src/serverprotocol/PasLS.Symbols.pas
@@ -1780,7 +1780,7 @@ var
 begin
   Entry := TSymbolTableEntry(SymbolTable.Find(FileName));
   if Entry <> nil then
-  begin
+    begin
     // Remove file from database (both symbols and entries tables)
     if (Database <> nil) and (Entry.Code <> nil) then
       Database.RemoveFile(Entry.Code.FileName);
@@ -1789,7 +1789,7 @@ begin
     Index := SymbolTable.FindIndexOf(FileName);
     if Index <> -1 then
       SymbolTable.Delete(Index);
-  end;
+    end;
 end;
 
 procedure TSymbolManager.UnloadFile(FileName: String);
@@ -1804,19 +1804,19 @@ begin
     Exit;
 
   if Database <> nil then
-  begin
+    begin
     // With database: just remove from memory, symbols stay in DB
     Index := SymbolTable.FindIndexOf(FileName);
     if Index <> -1 then
       SymbolTable.Delete(Index);  // Frees TSymbolTableEntry
-  end
+    end
   else
-  begin
+    begin
     // Without database: keep entry for workspace/symbol queries
     // Mark as unloaded so we know the file is closed
     Entry.Unloaded := True;
     // Note: Entry and its Symbols remain in memory
-  end;
+    end;
 end;
 
 function TSymbolManager.IsFileUnloaded(FileName: String): Boolean;
@@ -2002,19 +2002,19 @@ begin
     end
   else
     begin
-      // Handle reopening of unloaded files
-      if Entry.Unloaded then
+    // Handle reopening of unloaded files
+    if Entry.Unloaded then
       begin
-        Entry.Unloaded := False;
-        Entry.Modified := True;  // Force reload on next request
+      Entry.Unloaded := False;
+      Entry.Modified := True;  // Force reload on next request
       end;
 
-      if Entry.Code <> Code then
+    if Entry.Code <> Code then
       begin
-        // Update Entry.Code to point to the new buffer
-        // This handles the case when a file is moved/renamed:
-        // the filename (key) is the same but the Code buffer is different
-        Entry.Code := Code;
+      // Update Entry.Code to point to the new buffer
+      // This handles the case when a file is moved/renamed:
+      // the filename (key) is the same but the Code buffer is different
+      Entry.Code := Code;
       end;
     end;
   result := Entry;
@@ -2123,12 +2123,12 @@ begin
   NormalizedFile := NormalizePath(FileDir);
 
   for i := 0 to fWorkspacePaths.Count - 1 do
-  begin
+    begin
     WorkspacePath := fWorkspacePaths[i];
     // Check if file path starts with workspace path
     if Copy(NormalizedFile, 1, Length(WorkspacePath)) = WorkspacePath then
       Exit(True);
-  end;
+    end;
 end;
 
 finalization

--- a/src/serverprotocol/PasLS.Synchronization.pas
+++ b/src/serverprotocol/PasLS.Synchronization.pas
@@ -101,17 +101,19 @@ end;
 
 procedure TDidCloseTextDocument.Process(var Params : TDidCloseTextDocumentParams);
 var
-  FileName: String;
+  FileName, FullPath: String;
 begin
-  with Params do
-  begin
-    // Clean up symbol table entry and database records when file is closed
-    if SymbolManager <> nil then
-    begin
-      FileName := ExtractFileName(textDocument.LocalPath);
-      SymbolManager.RemoveFile(FileName);
-    end;
-  end;
+  if SymbolManager = nil then
+    Exit;
+
+  FullPath := Params.textDocument.LocalPath;
+  FileName := ExtractFileName(FullPath);
+
+  // Distinguish between workspace files and external files
+  if SymbolManager.IsFileInWorkspace(FullPath) then
+    SymbolManager.UnloadFile(FileName)   // Keep database symbols
+  else
+    SymbolManager.RemoveFile(FileName);  // Remove database symbols
 end;
 
 
@@ -120,15 +122,26 @@ end;
 procedure TDidSaveTextDocument.Process(var Params : TDidSaveTextDocumentParams);
 var
   Code: TCodeBuffer;
+  FullPath: String;
 begin
+  FullPath := Params.textDocument.LocalPath;
+  Code := CodeToolBoss.FindFile(FullPath);
 
-  Code := CodeToolBoss.FindFile(Params.textDocument.LocalPath);
+  if Code = nil then
+    Exit;
+
   if SymbolManager <> nil then
+  begin
+    // Always mark as modified
     SymbolManager.FileModified(Code);
-  DiagnosticsHandler.CheckSyntax(Transport,Code);
-  CheckInactiveRegions(Transport, Code, Params.textDocument.uri);
-  // ClearDiagnostics(Transport,Code);
 
+    // Proactively update database for workspace files
+    if SymbolManager.IsFileInWorkspace(FullPath) then
+      SymbolManager.Reload(Code, True);  // Force reload and DB update
+  end;
+
+  DiagnosticsHandler.CheckSyntax(Transport, Code);
+  CheckInactiveRegions(Transport, Code, Params.textDocument.uri);
 end;
 
 

--- a/src/serverprotocol/PasLS.Workspace.pas
+++ b/src/serverprotocol/PasLS.Workspace.pas
@@ -83,9 +83,13 @@ var
   Input: TWorkspaceSymbolParams;
 begin
   Input := specialize TLSPStreaming<TWorkspaceSymbolParams>.ToObject(Params);
-  Result := SymbolManager.FindWorkspaceSymbols(Input.query);
-  if not Assigned(Result) then
-    Result := TJSONNull.Create;
+  try
+    Result := SymbolManager.FindWorkspaceSymbols(Input.query);
+    if not Assigned(Result) then
+      Result := TJSONNull.Create;
+  finally
+    Input.Free;
+  end;
 end;
 
 { TDidChangeConfiguration }

--- a/src/tests/Tests.SublimeProfile.pas
+++ b/src/tests/Tests.SublimeProfile.pas
@@ -143,11 +143,11 @@ begin
   // Just delete the file - SymbolManager should be freed first in TearDown
   FTestCode := nil;
   if FTestFile <> '' then
-  begin
+    begin
     if FileExists(FTestFile) then
       DeleteFile(FTestFile);
     FTestFile := '';
-  end;
+    end;
 end;
 
 procedure TTestSublimeProfile.SetUp;

--- a/src/tests/Tests.SublimeProfile.pas
+++ b/src/tests/Tests.SublimeProfile.pas
@@ -115,9 +115,11 @@ var
   F: TextFile;
   ExistingBuffer: TCodeBuffer;
 begin
+  // Use GetTempFileName for guaranteed unique filename
   FTestFile := GetTempFileName('', 'testunit');
   FTestFile := ChangeFileExt(FTestFile, '.pas');
 
+  // Create file on disk
   AssignFile(F, FTestFile);
   try
     Rewrite(F);
@@ -126,16 +128,26 @@ begin
     CloseFile(F);
   end;
 
+  // Force CodeToolBoss to reload from disk if buffer already exists
+  // This is necessary because CodeToolBoss may have stale buffers from previous tests
   ExistingBuffer := CodeToolBoss.FindFile(FTestFile);
   if ExistingBuffer <> nil then
     ExistingBuffer.Revert;
+
+  // Load via CodeToolBoss
+  FTestCode := CodeToolBoss.LoadFile(FTestFile, True, False);
 end;
 
 procedure TTestSublimeProfile.CleanupTestFile;
 begin
-  if FileExists(FTestFile) then
-    DeleteFile(FTestFile);
-  FTestFile := '';
+  // Just delete the file - SymbolManager should be freed first in TearDown
+  FTestCode := nil;
+  if FTestFile <> '' then
+  begin
+    if FileExists(FTestFile) then
+      DeleteFile(FTestFile);
+    FTestFile := '';
+  end;
 end;
 
 procedure TTestSublimeProfile.SetUp;
@@ -146,12 +158,19 @@ begin
 
   if SymbolManager = nil then
     SymbolManager := TSymbolManager.Create;
+
+  // Reset capabilities to known state before each test
+  SetClientCapabilities(True);
+  // Each test sets its own profile via TClientProfile.SelectProfile
 end;
 
 procedure TTestSublimeProfile.TearDown;
 begin
   CleanupTestFile;
-  TClientProfile.SelectProfile('');  // Reset to default
+  FTestCode := nil;
+  // Reset client profile and capabilities for next test suite
+  TClientProfile.SelectProfile('');
+  SetClientCapabilities(False);
   inherited TearDown;
 end;
 
@@ -219,7 +238,6 @@ begin
   TClientProfile.SelectProfile('Sublime Text LSP');
 
   CreateTestFile(TEST_SUBLIME_UNIT);
-  FTestCode := CodeToolBoss.LoadFile(FTestFile, True, False);
   AssertNotNull('Code buffer should be loaded', FTestCode);
   SymbolManager.Reload(FTestCode, True);
   RawJSON := SymbolManager.FindDocumentSymbols(FTestFile).AsJSON;
@@ -237,7 +255,6 @@ begin
   TClientProfile.SelectProfile('Sublime Text LSP');
 
   CreateTestFile(TEST_SUBLIME_UNIT);
-  FTestCode := CodeToolBoss.LoadFile(FTestFile, True, False);
   AssertNotNull('Code buffer should be loaded', FTestCode);
   SymbolManager.Reload(FTestCode, True);
   RawJSON := SymbolManager.FindDocumentSymbols(FTestFile).AsJSON;
@@ -255,7 +272,6 @@ begin
   TClientProfile.SelectProfile('Sublime Text LSP');
 
   CreateTestFile(TEST_SUBLIME_UNIT);
-  FTestCode := CodeToolBoss.LoadFile(FTestFile, True, False);
   AssertNotNull('Code buffer should be loaded', FTestCode);
   SymbolManager.Reload(FTestCode, True);
   RawJSON := SymbolManager.FindDocumentSymbols(FTestFile).AsJSON;
@@ -279,7 +295,6 @@ begin
   TClientProfile.SelectProfile('Sublime Text LSP');
 
   CreateTestFile(TEST_SUBLIME_UNIT);
-  FTestCode := CodeToolBoss.LoadFile(FTestFile, True, False);
   AssertNotNull('Code buffer should be loaded', FTestCode);
   SymbolManager.Reload(FTestCode, True);
   RawJSON := SymbolManager.FindDocumentSymbols(FTestFile).AsJSON;
@@ -299,7 +314,6 @@ begin
   TClientProfile.SelectProfile('Sublime Text LSP');
 
   CreateTestFile(TEST_SUBLIME_UNIT);
-  FTestCode := CodeToolBoss.LoadFile(FTestFile, True, False);
   AssertNotNull('Code buffer should be loaded', FTestCode);
   SymbolManager.Reload(FTestCode, True);
   RawJSON := SymbolManager.FindDocumentSymbols(FTestFile).AsJSON;
@@ -322,7 +336,6 @@ begin
   TClientProfile.SelectProfile('Sublime Text LSP');
 
   CreateTestFile(TEST_SUBLIME_UNIT);
-  FTestCode := CodeToolBoss.LoadFile(FTestFile, True, False);
   AssertNotNull('Code buffer should be loaded', FTestCode);
   SymbolManager.Reload(FTestCode, True);
   RawJSON := SymbolManager.FindDocumentSymbols(FTestFile).AsJSON;
@@ -349,7 +362,6 @@ begin
   TClientProfile.SelectProfile('Sublime Text LSP');
 
   CreateTestFile(TEST_SUBLIME_UNIT);
-  FTestCode := CodeToolBoss.LoadFile(FTestFile, True, False);
   AssertNotNull('Code buffer should be loaded', FTestCode);
   SymbolManager.Reload(FTestCode, True);
   RawJSON := SymbolManager.FindDocumentSymbols(FTestFile).AsJSON;
@@ -387,7 +399,6 @@ begin
   TClientProfile.SelectProfile('Sublime Text LSP');
 
   CreateTestFile(TEST_SUBLIME_UNIT);
-  FTestCode := CodeToolBoss.LoadFile(FTestFile, True, False);
   AssertNotNull('Code buffer should be loaded', FTestCode);
   SymbolManager.Reload(FTestCode, True);
   RawJSON := SymbolManager.FindDocumentSymbols(FTestFile).AsJSON;
@@ -419,7 +430,6 @@ begin
   TClientProfile.SelectProfile('Sublime Text LSP');
 
   CreateTestFile(TEST_SUBLIME_UNIT);
-  FTestCode := CodeToolBoss.LoadFile(FTestFile, True, False);
   AssertNotNull('Code buffer should be loaded', FTestCode);
   SymbolManager.Reload(FTestCode, True);
   RawJSON := SymbolManager.FindDocumentSymbols(FTestFile).AsJSON;
@@ -445,7 +455,6 @@ begin
   TClientProfile.SelectProfile('Sublime Text LSP');
 
   CreateTestFile(TEST_SUBLIME_UNIT);
-  FTestCode := CodeToolBoss.LoadFile(FTestFile, True, False);
   AssertNotNull('Code buffer should be loaded', FTestCode);
   SymbolManager.Reload(FTestCode, True);
   RawJSON := SymbolManager.FindDocumentSymbols(FTestFile).AsJSON;
@@ -470,7 +479,6 @@ begin
   TClientProfile.SelectProfile('Sublime Text LSP');
 
   CreateTestFile(TEST_SUBLIME_UNIT);
-  FTestCode := CodeToolBoss.LoadFile(FTestFile, True, False);
   AssertNotNull('Code buffer should be loaded', FTestCode);
   SymbolManager.Reload(FTestCode, True);
   RawJSON := SymbolManager.FindDocumentSymbols(FTestFile).AsJSON;
@@ -495,7 +503,6 @@ begin
   TClientProfile.SelectProfile('Sublime Text LSP');
 
   CreateTestFile(TEST_SUBLIME_UNIT);
-  FTestCode := CodeToolBoss.LoadFile(FTestFile, True, False);
   AssertNotNull('Code buffer should be loaded', FTestCode);
   SymbolManager.Reload(FTestCode, True);
   RawJSON := SymbolManager.FindDocumentSymbols(FTestFile).AsJSON;
@@ -524,7 +531,6 @@ begin
   TClientProfile.SelectProfile('Sublime Text LSP');
 
   CreateTestFile(TEST_SUBLIME_UNIT);
-  FTestCode := CodeToolBoss.LoadFile(FTestFile, True, False);
   AssertNotNull('Code buffer should be loaded', FTestCode);
   SymbolManager.Reload(FTestCode, True);
   RawJSON := SymbolManager.FindDocumentSymbols(FTestFile).AsJSON;
@@ -548,7 +554,6 @@ begin
   TClientProfile.SelectProfile('Sublime Text LSP');
 
   CreateTestFile(TEST_SUBLIME_UNIT);
-  FTestCode := CodeToolBoss.LoadFile(FTestFile, True, False);
   AssertNotNull('Code buffer should be loaded', FTestCode);
   SymbolManager.Reload(FTestCode, True);
   RawJSON := SymbolManager.FindDocumentSymbols(FTestFile).AsJSON;
@@ -571,7 +576,6 @@ var
 begin
   // Compare Sublime profile output with Default profile
   CreateTestFile(TEST_SUBLIME_UNIT);
-  FTestCode := CodeToolBoss.LoadFile(FTestFile, True, False);
   AssertNotNull('Code buffer should be loaded', FTestCode);
 
   // Get Sublime profile symbols
@@ -613,7 +617,6 @@ begin
   TClientProfile.SelectProfile('Sublime Text LSP');
 
   CreateTestFile(TEST_SUBLIME_UNIT);
-  FTestCode := CodeToolBoss.LoadFile(FTestFile, True, False);
   AssertNotNull('Code buffer should be loaded', FTestCode);
   SymbolManager.Reload(FTestCode, True);
   RawJSON := SymbolManager.FindDocumentSymbols(FTestFile).AsJSON;
@@ -637,7 +640,6 @@ begin
   TClientProfile.SelectProfile('Sublime Text LSP');
 
   CreateTestFile(TEST_SUBLIME_UNIT);
-  FTestCode := CodeToolBoss.LoadFile(FTestFile, True, False);
   AssertNotNull('Code buffer should be loaded', FTestCode);
   SymbolManager.Reload(FTestCode, True);
   RawJSON := SymbolManager.FindDocumentSymbols(FTestFile).AsJSON;

--- a/src/tests/Tests.SymbolPersistence.pas
+++ b/src/tests/Tests.SymbolPersistence.pas
@@ -1,0 +1,376 @@
+unit Tests.SymbolPersistence;
+
+{$mode objfpc}{$H+}
+
+interface
+
+uses
+  Classes, SysUtils, fpcunit, testregistry, fpjson, jsonparser,
+  CodeToolManager, CodeCache,
+  PasLS.Symbols, PasLS.ClientProfile;
+
+type
+
+  { TTestSymbolPersistence }
+
+  TTestSymbolPersistence = class(TTestCase)
+  private
+    FTestFile: String;
+    FTestCode: TCodeBuffer;
+    procedure CreateTestFile(const AContent: String);
+    procedure CleanupTestFile;
+    function ParseSymbols(const RawJSON: String): TJSONArray;
+  protected
+    procedure SetUp; override;
+    procedure TearDown; override;
+  published
+    // Phase 1: Infrastructure tests
+    procedure TestWorkspacePathsInitialized;
+    procedure TestNormalizePathCaseInsensitiveOnWindows;
+    procedure TestIsFileInWorkspacePositive;
+    procedure TestIsFileInWorkspaceNegative;
+
+    // Phase 2: didClose behavior tests
+    procedure TestUnloadFileKeepsDBSymbols;
+    procedure TestUnloadFileSetsUnloadedFlag;
+    procedure TestRemoveFileDeletesDBSymbols;
+    procedure TestReopenUnloadedFileReloads;
+
+    // Phase 3: didSave behavior tests
+    procedure TestDidSaveUpdatesDatabase;
+    procedure TestWorkspaceSymbolAfterDidSave;
+  end;
+
+implementation
+
+const
+  TEST_WORKSPACE_UNIT =
+    'unit TestWorkspace;' + LineEnding +
+    '' + LineEnding +
+    '{$mode objfpc}{$H+}' + LineEnding +
+    '' + LineEnding +
+    'interface' + LineEnding +
+    '' + LineEnding +
+    'type' + LineEnding +
+    '  TMyClass = class' + LineEnding +
+    '    procedure MethodA;' + LineEnding +
+    '  end;' + LineEnding +
+    '' + LineEnding +
+    'function GlobalFunc: Boolean;' + LineEnding +
+    '' + LineEnding +
+    'implementation' + LineEnding +
+    '' + LineEnding +
+    'procedure TMyClass.MethodA;' + LineEnding +
+    'begin' + LineEnding +
+    'end;' + LineEnding +
+    '' + LineEnding +
+    'function GlobalFunc: Boolean;' + LineEnding +
+    'begin' + LineEnding +
+    '  Result := True;' + LineEnding +
+    'end;' + LineEnding +
+    '' + LineEnding +
+    'end.';
+
+{ TTestSymbolPersistence }
+
+procedure TTestSymbolPersistence.CreateTestFile(const AContent: String);
+var
+  F: TextFile;
+  ExistingBuffer: TCodeBuffer;
+begin
+  FTestFile := GetTempFileName('', 'testunit');
+  FTestFile := ChangeFileExt(FTestFile, '.pas');
+
+  AssignFile(F, FTestFile);
+  try
+    Rewrite(F);
+    Write(F, AContent);
+  finally
+    CloseFile(F);
+  end;
+
+  ExistingBuffer := CodeToolBoss.FindFile(FTestFile);
+  if ExistingBuffer <> nil then
+    ExistingBuffer.Revert;
+end;
+
+procedure TTestSymbolPersistence.CleanupTestFile;
+begin
+  FTestCode := nil;
+  if FTestFile <> '' then
+  begin
+    if FileExists(FTestFile) then
+      DeleteFile(FTestFile);
+    FTestFile := '';
+  end;
+end;
+
+function TTestSymbolPersistence.ParseSymbols(const RawJSON: String): TJSONArray;
+var
+  JSONData: TJSONData;
+begin
+  Result := nil;
+  if RawJSON = '' then
+    Exit;
+  JSONData := GetJSON(RawJSON);
+  if JSONData is TJSONArray then
+    Result := JSONData as TJSONArray
+  else
+    JSONData.Free;
+end;
+
+procedure TTestSymbolPersistence.SetUp;
+begin
+  inherited SetUp;
+  FTestCode := nil;
+  FTestFile := '';
+
+  if SymbolManager = nil then
+    SymbolManager := TSymbolManager.Create;
+
+  TClientProfile.SelectProfile('');
+  SetClientCapabilities(True);
+end;
+
+procedure TTestSymbolPersistence.TearDown;
+begin
+  CleanupTestFile;
+  FTestCode := nil;
+  TClientProfile.SelectProfile('');
+  SetClientCapabilities(False);
+  inherited TearDown;
+end;
+
+// Phase 1: Infrastructure tests
+
+procedure TTestSymbolPersistence.TestWorkspacePathsInitialized;
+begin
+  // WorkspacePaths should be initialized (not nil) after SymbolManager creation
+  AssertNotNull('WorkspacePaths should be initialized', SymbolManager.WorkspacePaths);
+end;
+
+procedure TTestSymbolPersistence.TestNormalizePathCaseInsensitiveOnWindows;
+var
+  Path1, Path2: String;
+begin
+  {$IFDEF WINDOWS}
+  Path1 := SymbolManager.NormalizePath('C:\Test\Path');
+  Path2 := SymbolManager.NormalizePath('c:\test\path');
+  AssertEquals('Paths should be equal on Windows (case insensitive)', Path1, Path2);
+  {$ELSE}
+  // On Unix, paths are case-sensitive
+  Path1 := SymbolManager.NormalizePath('/Test/Path');
+  Path2 := SymbolManager.NormalizePath('/test/path');
+  AssertTrue('Paths should be different on Unix (case sensitive)', Path1 <> Path2);
+  {$ENDIF}
+end;
+
+procedure TTestSymbolPersistence.TestIsFileInWorkspacePositive;
+var
+  TestDir: String;
+begin
+  // Add a workspace path
+  TestDir := ExtractFilePath(ParamStr(0));
+  SymbolManager.WorkspacePaths.Clear;
+  SymbolManager.WorkspacePaths.Add(SymbolManager.NormalizePath(TestDir));
+
+  // File in workspace should return True
+  AssertTrue('File in workspace should return True',
+    SymbolManager.IsFileInWorkspace(TestDir + 'test.pas'));
+end;
+
+procedure TTestSymbolPersistence.TestIsFileInWorkspaceNegative;
+var
+  TestDir: String;
+begin
+  // Add a workspace path
+  TestDir := ExtractFilePath(ParamStr(0));
+  SymbolManager.WorkspacePaths.Clear;
+  SymbolManager.WorkspacePaths.Add(SymbolManager.NormalizePath(TestDir));
+
+  // File outside workspace should return False
+  {$IFDEF WINDOWS}
+  AssertFalse('File outside workspace should return False',
+    SymbolManager.IsFileInWorkspace('C:\OtherDir\test.pas'));
+  {$ELSE}
+  AssertFalse('File outside workspace should return False',
+    SymbolManager.IsFileInWorkspace('/other/dir/test.pas'));
+  {$ENDIF}
+end;
+
+// Phase 2: didClose behavior tests
+// NOTE: These tests require UnloadFile, IsFileUnloaded methods (Task 5+)
+
+procedure TTestSymbolPersistence.TestUnloadFileKeepsDBSymbols;
+begin
+  // TODO: Implement when UnloadFile is added (Task 5+)
+  Ignore('UnloadFile not yet implemented');
+end;
+
+procedure TTestSymbolPersistence.TestUnloadFileSetsUnloadedFlag;
+var
+  FileName: String;
+begin
+  // Test that UnloadFile sets the Unloaded flag (without database)
+  CreateTestFile(TEST_WORKSPACE_UNIT);
+  FTestCode := CodeToolBoss.LoadFile(FTestFile, True, False);
+  AssertNotNull('Code buffer should be loaded', FTestCode);
+
+  // Add file to workspace
+  SymbolManager.WorkspacePaths.Clear;
+  SymbolManager.WorkspacePaths.Add(SymbolManager.NormalizePath(ExtractFilePath(FTestFile)));
+
+  // Load symbols into memory
+  SymbolManager.Reload(FTestCode, True);
+
+  // File should not be unloaded yet
+  FileName := ExtractFileName(FTestFile);
+  AssertFalse('File should not be unloaded initially',
+    SymbolManager.IsFileUnloaded(FileName));
+
+  // Unload the file (simulating didClose for workspace file)
+  SymbolManager.UnloadFile(FileName);
+
+  // Now the file should be marked as unloaded
+  AssertTrue('File should be marked as unloaded after UnloadFile',
+    SymbolManager.IsFileUnloaded(FileName));
+end;
+
+procedure TTestSymbolPersistence.TestRemoveFileDeletesDBSymbols;
+var
+  Result: TJSONData;
+  SymbolArray: TJSONArray;
+  FileName: String;
+begin
+  CreateTestFile(TEST_WORKSPACE_UNIT);
+  FTestCode := CodeToolBoss.LoadFile(FTestFile, True, False);
+  AssertNotNull('Code buffer should be loaded', FTestCode);
+
+  // Do NOT add to workspace paths (external file)
+  SymbolManager.WorkspacePaths.Clear;
+
+  SymbolManager.Reload(FTestCode, True);
+
+  // Verify symbols exist before remove
+  Result := SymbolManager.FindWorkspaceSymbols('TMyClass');
+  SymbolArray := ParseSymbols(Result.AsJSON);
+  try
+    AssertTrue('Should find TMyClass before remove', SymbolArray.Count > 0);
+  finally
+    SymbolArray.Free;
+  end;
+
+  // Remove the file (simulating didClose for external file)
+  FileName := ExtractFileName(FTestFile);
+  SymbolManager.RemoveFile(FileName);
+
+  // Verify symbols are gone after remove
+  Result := SymbolManager.FindWorkspaceSymbols('TMyClass');
+  SymbolArray := ParseSymbols(Result.AsJSON);
+  try
+    AssertEquals('Should NOT find TMyClass after remove', 0, SymbolArray.Count);
+  finally
+    SymbolArray.Free;
+  end;
+end;
+
+procedure TTestSymbolPersistence.TestReopenUnloadedFileReloads;
+var
+  FileName: String;
+begin
+  // Test that reopening an unloaded file clears the Unloaded flag
+  // via Reload (which internally calls GetEntry)
+  CreateTestFile(TEST_WORKSPACE_UNIT);
+  FTestCode := CodeToolBoss.LoadFile(FTestFile, True, False);
+  AssertNotNull('Code buffer should be loaded', FTestCode);
+
+  // Add file to workspace
+  SymbolManager.WorkspacePaths.Clear;
+  SymbolManager.WorkspacePaths.Add(SymbolManager.NormalizePath(ExtractFilePath(FTestFile)));
+
+  // Load symbols into memory (this calls GetEntry internally)
+  SymbolManager.Reload(FTestCode, True);
+  FileName := ExtractFileName(FTestFile);
+
+  // File should not be unloaded yet
+  AssertFalse('File should not be unloaded initially',
+    SymbolManager.IsFileUnloaded(FileName));
+
+  // Unload the file (simulating didClose for workspace file)
+  SymbolManager.UnloadFile(FileName);
+
+  // Now the file should be marked as unloaded
+  AssertTrue('File should be marked as unloaded after UnloadFile',
+    SymbolManager.IsFileUnloaded(FileName));
+
+  // Reopen the file via Reload (which calls GetEntry internally)
+  // GetEntry should clear the Unloaded flag and set Modified
+  SymbolManager.Reload(FTestCode, True);
+
+  // The file should no longer be marked as unloaded
+  AssertFalse('File should not be unloaded after reopening via Reload',
+    SymbolManager.IsFileUnloaded(FileName));
+end;
+
+// Phase 3: didSave behavior tests
+
+procedure TTestSymbolPersistence.TestDidSaveUpdatesDatabase;
+begin
+  // This test validates that saving updates the database proactively
+  // Will be implemented with the didSave handler changes
+  CreateTestFile(TEST_WORKSPACE_UNIT);
+  FTestCode := CodeToolBoss.LoadFile(FTestFile, True, False);
+  AssertNotNull('Code buffer should be loaded', FTestCode);
+
+  SymbolManager.WorkspacePaths.Clear;
+  SymbolManager.WorkspacePaths.Add(SymbolManager.NormalizePath(ExtractFilePath(FTestFile)));
+
+  // Mark as modified (simulating didChange)
+  SymbolManager.FileModified(FTestCode);
+
+  // Proactive reload (simulating didSave for workspace file)
+  if SymbolManager.IsFileInWorkspace(FTestFile) then
+    SymbolManager.Reload(FTestCode, True);
+
+  // Verify symbols are in database/memory
+  AssertNotNull('Symbols should be available after save',
+    SymbolManager.FindWorkspaceSymbols('TMyClass'));
+end;
+
+procedure TTestSymbolPersistence.TestWorkspaceSymbolAfterDidSave;
+var
+  Result: TJSONData;
+  SymbolArray: TJSONArray;
+begin
+  CreateTestFile(TEST_WORKSPACE_UNIT);
+  FTestCode := CodeToolBoss.LoadFile(FTestFile, True, False);
+  AssertNotNull('Code buffer should be loaded', FTestCode);
+
+  SymbolManager.WorkspacePaths.Clear;
+  SymbolManager.WorkspacePaths.Add(SymbolManager.NormalizePath(ExtractFilePath(FTestFile)));
+
+  // Initial load
+  SymbolManager.Reload(FTestCode, True);
+
+  // Modify content (simulating edit)
+  FTestCode.Source := FTestCode.Source + LineEnding + '// Modified';
+  SymbolManager.FileModified(FTestCode);
+
+  // Save triggers reload for workspace files
+  if SymbolManager.IsFileInWorkspace(FTestFile) then
+    SymbolManager.Reload(FTestCode, True);
+
+  // workspace/symbol should still work
+  Result := SymbolManager.FindWorkspaceSymbols('');
+  SymbolArray := ParseSymbols(Result.AsJSON);
+  try
+    AssertTrue('workspace/symbol should return results after save', SymbolArray.Count > 0);
+  finally
+    SymbolArray.Free;
+  end;
+end;
+
+initialization
+  RegisterTest(TTestSymbolPersistence);
+
+end.

--- a/src/tests/Tests.SymbolPersistence.pas
+++ b/src/tests/Tests.SymbolPersistence.pas
@@ -98,11 +98,11 @@ procedure TTestSymbolPersistence.CleanupTestFile;
 begin
   FTestCode := nil;
   if FTestFile <> '' then
-  begin
+    begin
     if FileExists(FTestFile) then
       DeleteFile(FTestFile);
     FTestFile := '';
-  end;
+    end;
 end;
 
 function TTestSymbolPersistence.ParseSymbols(const RawJSON: String): TJSONArray;

--- a/src/tests/Tests.WorkspaceSymbol.pas
+++ b/src/tests/Tests.WorkspaceSymbol.pas
@@ -111,11 +111,11 @@ begin
   // Just delete the file - SymbolManager should be freed first in TearDown
   FTestCode := nil;
   if FTestFile <> '' then
-  begin
+    begin
     if FileExists(FTestFile) then
       DeleteFile(FTestFile);
     FTestFile := '';
-  end;
+    end;
 end;
 
 function TTestWorkspaceSymbol.ParseSymbols(const RawJSON: String): TJSONArray;

--- a/src/tests/Tests.WorkspaceSymbol.pas
+++ b/src/tests/Tests.WorkspaceSymbol.pas
@@ -1,0 +1,425 @@
+unit Tests.WorkspaceSymbol;
+
+{$mode objfpc}{$H+}
+
+interface
+
+uses
+  Classes, SysUtils, fpcunit, testregistry, fpjson, jsonparser,
+  CodeToolManager, CodeCache,
+  PasLS.Symbols, PasLS.ClientProfile;
+
+type
+
+  { TTestWorkspaceSymbol }
+
+  TTestWorkspaceSymbol = class(TTestCase)
+  private
+    FTestFile: String;
+    FTestCode: TCodeBuffer;
+    procedure CreateTestFile(const AContent: String);
+    procedure CleanupTestFile;
+    function ParseSymbols(const RawJSON: String): TJSONArray;
+  protected
+    procedure SetUp; override;
+    procedure TearDown; override;
+  published
+    procedure TestReturnsSymbolInformationFormat;
+    procedure TestHasLocationField;
+    procedure TestNoChildrenField;
+    procedure TestNoSelectionRangeField;
+    procedure TestQueryFilterByName;
+    procedure TestQueryFilterCaseInsensitive;
+    procedure TestEmptyQueryReturnsAll;
+    procedure TestContainsExpectedSymbols;
+  end;
+
+implementation
+
+const
+  TEST_WORKSPACE_UNIT =
+    'unit TestWorkspace;' + LineEnding +
+    '' + LineEnding +
+    '{$mode objfpc}{$H+}' + LineEnding +
+    '' + LineEnding +
+    'interface' + LineEnding +
+    '' + LineEnding +
+    'type' + LineEnding +
+    '  TMyClass = class' + LineEnding +
+    '    procedure MethodA;' + LineEnding +
+    '    function MethodB: Integer;' + LineEnding +
+    '  end;' + LineEnding +
+    '' + LineEnding +
+    '  TMyRecord = record' + LineEnding +
+    '    Field1: Integer;' + LineEnding +
+    '  end;' + LineEnding +
+    '' + LineEnding +
+    'function GlobalFunc: Boolean;' + LineEnding +
+    'procedure GlobalProc;' + LineEnding +
+    '' + LineEnding +
+    'implementation' + LineEnding +
+    '' + LineEnding +
+    'procedure TMyClass.MethodA;' + LineEnding +
+    'begin' + LineEnding +
+    'end;' + LineEnding +
+    '' + LineEnding +
+    'function TMyClass.MethodB: Integer;' + LineEnding +
+    'begin' + LineEnding +
+    '  Result := 0;' + LineEnding +
+    'end;' + LineEnding +
+    '' + LineEnding +
+    'function GlobalFunc: Boolean;' + LineEnding +
+    'begin' + LineEnding +
+    '  Result := True;' + LineEnding +
+    'end;' + LineEnding +
+    '' + LineEnding +
+    'procedure GlobalProc;' + LineEnding +
+    'begin' + LineEnding +
+    'end;' + LineEnding +
+    '' + LineEnding +
+    'end.';
+
+{ TTestWorkspaceSymbol }
+
+procedure TTestWorkspaceSymbol.CreateTestFile(const AContent: String);
+var
+  F: TextFile;
+  ExistingBuffer: TCodeBuffer;
+begin
+  // Use GetTempFileName for guaranteed unique filename (matches TTestDocumentSymbol pattern)
+  FTestFile := GetTempFileName('', 'testunit');
+  FTestFile := ChangeFileExt(FTestFile, '.pas');
+
+  AssignFile(F, FTestFile);
+  try
+    Rewrite(F);
+    Write(F, AContent);
+  finally
+    CloseFile(F);
+  end;
+
+  // Force CodeToolBoss to reload from disk if buffer already exists
+  // This is necessary because GetTempFileName may reuse same filename
+  // after previous test deleted the file
+  ExistingBuffer := CodeToolBoss.FindFile(FTestFile);
+  if ExistingBuffer <> nil then
+    ExistingBuffer.Revert;
+end;
+
+procedure TTestWorkspaceSymbol.CleanupTestFile;
+begin
+  // Just delete the file - SymbolManager should be freed first in TearDown
+  FTestCode := nil;
+  if FTestFile <> '' then
+  begin
+    if FileExists(FTestFile) then
+      DeleteFile(FTestFile);
+    FTestFile := '';
+  end;
+end;
+
+function TTestWorkspaceSymbol.ParseSymbols(const RawJSON: String): TJSONArray;
+var
+  JSONData: TJSONData;
+begin
+  Result := nil;
+  if RawJSON = '' then
+    Exit;
+  JSONData := GetJSON(RawJSON);
+  if JSONData is TJSONArray then
+    Result := JSONData as TJSONArray
+  else
+    JSONData.Free;
+end;
+
+procedure TTestWorkspaceSymbol.SetUp;
+begin
+  inherited SetUp;
+  FTestCode := nil;
+  FTestFile := '';
+
+  // Create SymbolManager if it doesn't exist
+  if SymbolManager = nil then
+    SymbolManager := TSymbolManager.Create;
+
+  // Reset client profile to default (in case previous test suite changed it)
+  TClientProfile.SelectProfile('');
+  // Set hierarchical mode for tests (matches TTestDocumentSymbol pattern)
+  SetClientCapabilities(True);
+end;
+
+procedure TTestWorkspaceSymbol.TearDown;
+begin
+  CleanupTestFile;
+  FTestCode := nil;
+  // Reset client profile and capabilities for next test suite
+  TClientProfile.SelectProfile('');
+  SetClientCapabilities(False);
+  inherited TearDown;
+end;
+
+procedure TTestWorkspaceSymbol.TestReturnsSymbolInformationFormat;
+var
+  Result: TJSONData;
+  RawJSON: String;
+  SymbolArray: TJSONArray;
+  Symbol: TJSONObject;
+begin
+  CreateTestFile(TEST_WORKSPACE_UNIT);
+  FTestCode := CodeToolBoss.LoadFile(FTestFile, True, False);
+  if FTestCode = nil then
+    Fail('LoadFile returned nil for: ' + FTestFile + ' (exists=' + BoolToStr(FileExists(FTestFile), True) + ')');
+  AssertNotNull('Code buffer should be loaded', FTestCode);
+  SymbolManager.Reload(FTestCode, True);
+
+  Result := SymbolManager.FindWorkspaceSymbols('');
+  AssertNotNull('FindWorkspaceSymbols should return result', Result);
+
+  RawJSON := Result.AsJSON;
+  SymbolArray := ParseSymbols(RawJSON);
+  try
+    AssertNotNull('Result should be a JSON array', SymbolArray);
+    AssertTrue('Should have at least one symbol', SymbolArray.Count > 0);
+
+    Symbol := SymbolArray.Items[0] as TJSONObject;
+    AssertNotNull('First item should be an object', Symbol);
+    AssertTrue('Should have name field', Symbol.Find('name') <> nil);
+    AssertTrue('Should have kind field', Symbol.Find('kind') <> nil);
+  finally
+    SymbolArray.Free;
+  end;
+end;
+
+procedure TTestWorkspaceSymbol.TestHasLocationField;
+var
+  Result: TJSONData;
+  SymbolArray: TJSONArray;
+  I: Integer;
+  Symbol: TJSONObject;
+  Location: TJSONObject;
+begin
+  CreateTestFile(TEST_WORKSPACE_UNIT);
+  FTestCode := CodeToolBoss.LoadFile(FTestFile, True, False);
+  AssertNotNull('Code buffer should be loaded', FTestCode);
+  SymbolManager.Reload(FTestCode, True);
+
+  Result := SymbolManager.FindWorkspaceSymbols('');
+  SymbolArray := ParseSymbols(Result.AsJSON);
+  try
+    AssertNotNull('Result should be a JSON array', SymbolArray);
+
+    for I := 0 to SymbolArray.Count - 1 do
+    begin
+      Symbol := SymbolArray.Items[I] as TJSONObject;
+      AssertTrue('Symbol ' + IntToStr(I) + ' should have location field',
+        Symbol.Find('location') <> nil);
+
+      Location := Symbol.FindPath('location') as TJSONObject;
+      AssertNotNull('location should be an object', Location);
+      AssertTrue('location should have uri', Location.Find('uri') <> nil);
+      AssertTrue('location should have range', Location.Find('range') <> nil);
+    end;
+  finally
+    SymbolArray.Free;
+  end;
+end;
+
+procedure TTestWorkspaceSymbol.TestNoChildrenField;
+var
+  Result: TJSONData;
+  SymbolArray: TJSONArray;
+  I: Integer;
+  Symbol: TJSONObject;
+begin
+  CreateTestFile(TEST_WORKSPACE_UNIT);
+  FTestCode := CodeToolBoss.LoadFile(FTestFile, True, False);
+  AssertNotNull('Code buffer should be loaded', FTestCode);
+  SymbolManager.Reload(FTestCode, True);
+
+  Result := SymbolManager.FindWorkspaceSymbols('');
+  SymbolArray := ParseSymbols(Result.AsJSON);
+  try
+    AssertNotNull('Result should be a JSON array', SymbolArray);
+
+    for I := 0 to SymbolArray.Count - 1 do
+    begin
+      Symbol := SymbolArray.Items[I] as TJSONObject;
+      AssertTrue('Symbol ' + Symbol.Get('name', '?') + ' should NOT have children field',
+        Symbol.Find('children') = nil);
+    end;
+  finally
+    SymbolArray.Free;
+  end;
+end;
+
+procedure TTestWorkspaceSymbol.TestNoSelectionRangeField;
+var
+  Result: TJSONData;
+  SymbolArray: TJSONArray;
+  I: Integer;
+  Symbol: TJSONObject;
+begin
+  CreateTestFile(TEST_WORKSPACE_UNIT);
+  FTestCode := CodeToolBoss.LoadFile(FTestFile, True, False);
+  AssertNotNull('Code buffer should be loaded', FTestCode);
+  SymbolManager.Reload(FTestCode, True);
+
+  Result := SymbolManager.FindWorkspaceSymbols('');
+  SymbolArray := ParseSymbols(Result.AsJSON);
+  try
+    AssertNotNull('Result should be a JSON array', SymbolArray);
+
+    for I := 0 to SymbolArray.Count - 1 do
+    begin
+      Symbol := SymbolArray.Items[I] as TJSONObject;
+      AssertTrue('Symbol ' + Symbol.Get('name', '?') + ' should NOT have selectionRange field',
+        Symbol.Find('selectionRange') = nil);
+    end;
+  finally
+    SymbolArray.Free;
+  end;
+end;
+
+procedure TTestWorkspaceSymbol.TestQueryFilterByName;
+var
+  Result: TJSONData;
+  SymbolArray: TJSONArray;
+  I: Integer;
+  Symbol: TJSONObject;
+  SymbolName: String;
+  FoundMethodA, FoundMethodB: Boolean;
+begin
+  CreateTestFile(TEST_WORKSPACE_UNIT);
+  FTestCode := CodeToolBoss.LoadFile(FTestFile, True, False);
+  AssertNotNull('Code buffer should be loaded', FTestCode);
+  SymbolManager.Reload(FTestCode, True);
+
+  Result := SymbolManager.FindWorkspaceSymbols('Method');
+  SymbolArray := ParseSymbols(Result.AsJSON);
+  try
+    AssertNotNull('Result should be a JSON array', SymbolArray);
+    AssertTrue('Query "Method" should return results', SymbolArray.Count > 0);
+
+    FoundMethodA := False;
+    FoundMethodB := False;
+    for I := 0 to SymbolArray.Count - 1 do
+    begin
+      Symbol := SymbolArray.Items[I] as TJSONObject;
+      SymbolName := Symbol.Get('name', '');
+      if Pos('MethodA', SymbolName) > 0 then
+        FoundMethodA := True;
+      if Pos('MethodB', SymbolName) > 0 then
+        FoundMethodB := True;
+    end;
+
+    AssertTrue('Should find MethodA', FoundMethodA);
+    AssertTrue('Should find MethodB', FoundMethodB);
+  finally
+    SymbolArray.Free;
+  end;
+end;
+
+procedure TTestWorkspaceSymbol.TestQueryFilterCaseInsensitive;
+var
+  ResultUpper, ResultLower: TJSONData;
+  UpperArray, LowerArray: TJSONArray;
+begin
+  CreateTestFile(TEST_WORKSPACE_UNIT);
+  FTestCode := CodeToolBoss.LoadFile(FTestFile, True, False);
+  AssertNotNull('Code buffer should be loaded', FTestCode);
+  SymbolManager.Reload(FTestCode, True);
+
+  ResultUpper := SymbolManager.FindWorkspaceSymbols('GLOBAL');
+  ResultLower := SymbolManager.FindWorkspaceSymbols('global');
+
+  UpperArray := ParseSymbols(ResultUpper.AsJSON);
+  LowerArray := ParseSymbols(ResultLower.AsJSON);
+  try
+    AssertNotNull('Upper case query should return array', UpperArray);
+    AssertNotNull('Lower case query should return array', LowerArray);
+
+    // Both queries should find Global symbols
+    AssertTrue('Upper case query should find results', UpperArray.Count > 0);
+    AssertTrue('Lower case query should find results', LowerArray.Count > 0);
+  finally
+    UpperArray.Free;
+    LowerArray.Free;
+  end;
+end;
+
+procedure TTestWorkspaceSymbol.TestEmptyQueryReturnsAll;
+var
+  ResultEmpty, ResultWithQuery: TJSONData;
+  EmptyArray, QueryArray: TJSONArray;
+begin
+  CreateTestFile(TEST_WORKSPACE_UNIT);
+  FTestCode := CodeToolBoss.LoadFile(FTestFile, True, False);
+  AssertNotNull('Code buffer should be loaded', FTestCode);
+  SymbolManager.Reload(FTestCode, True);
+
+  ResultEmpty := SymbolManager.FindWorkspaceSymbols('');
+  ResultWithQuery := SymbolManager.FindWorkspaceSymbols('TMyClass');
+
+  EmptyArray := ParseSymbols(ResultEmpty.AsJSON);
+  QueryArray := ParseSymbols(ResultWithQuery.AsJSON);
+  try
+    AssertNotNull('Empty query should return array', EmptyArray);
+    AssertNotNull('Specific query should return array', QueryArray);
+
+    // Empty query should return more or equal symbols
+    AssertTrue('Empty query should return at least as many symbols',
+      EmptyArray.Count >= QueryArray.Count);
+  finally
+    EmptyArray.Free;
+    QueryArray.Free;
+  end;
+end;
+
+procedure TTestWorkspaceSymbol.TestContainsExpectedSymbols;
+var
+  Result: TJSONData;
+  SymbolArray: TJSONArray;
+  I: Integer;
+  Symbol: TJSONObject;
+  SymbolName: String;
+  FoundClass, FoundRecord, FoundGlobalFunc, FoundGlobalProc: Boolean;
+begin
+  CreateTestFile(TEST_WORKSPACE_UNIT);
+  FTestCode := CodeToolBoss.LoadFile(FTestFile, True, False);
+  AssertNotNull('Code buffer should be loaded', FTestCode);
+  SymbolManager.Reload(FTestCode, True);
+
+  Result := SymbolManager.FindWorkspaceSymbols('');
+  SymbolArray := ParseSymbols(Result.AsJSON);
+  try
+    AssertNotNull('Result should be a JSON array', SymbolArray);
+
+    FoundClass := False;
+    FoundRecord := False;
+    FoundGlobalFunc := False;
+    FoundGlobalProc := False;
+
+    for I := 0 to SymbolArray.Count - 1 do
+    begin
+      Symbol := SymbolArray.Items[I] as TJSONObject;
+      SymbolName := Symbol.Get('name', '');
+
+      if SymbolName = 'TMyClass' then FoundClass := True;
+      if SymbolName = 'TMyRecord' then FoundRecord := True;
+      if SymbolName = 'GlobalFunc' then FoundGlobalFunc := True;
+      if SymbolName = 'GlobalProc' then FoundGlobalProc := True;
+    end;
+
+    AssertTrue('Should contain TMyClass', FoundClass);
+    AssertTrue('Should contain TMyRecord', FoundRecord);
+    AssertTrue('Should contain GlobalFunc', FoundGlobalFunc);
+    AssertTrue('Should contain GlobalProc', FoundGlobalProc);
+  finally
+    SymbolArray.Free;
+  end;
+end;
+
+initialization
+  RegisterTest(TTestWorkspaceSymbol);
+
+end.

--- a/src/tests/testlsp.lpr
+++ b/src/tests/testlsp.lpr
@@ -4,7 +4,7 @@ program testlsp;
 
 uses
   Classes, consoletestrunner, Tests.Basic, Tests.ClientProfile, Tests.DocumentSymbol,
-  Tests.SublimeProfile;
+  Tests.SublimeProfile, Tests.SymbolPersistence, Tests.WorkspaceSymbol;
 
 type
 


### PR DESCRIPTION
## Summary
- Fix workspace/symbol not working without database file on first open
- Now workspace/symbol works with or without database (uses in-memory data when no database configured)
- Fix multiple memory leaks in symbol management

## Changes
- With database: symbols stored in SQLite, memory freed after serialization
- Without database: symbols kept in memory for queries

## Memory leak fixes
- Fix OverloadMap TSymbol leak in TSymbolExtractor.Destroy
- Add TSQLiteDatabase.Destroy to properly close SQLite handle
- Fix TSymbolManager.Destroy order (free fDatabase before other cleanup)
- Fix Input param leak in TWorkspaceSymbol.Process

## Test plan
- [x] Add workspace/symbol test cases (Tests.WorkspaceSymbol.pas)
- [x] Verify workspace/symbol works without database
- [x] Verify memory leaks are resolved