### PR TITLE
fix: ensure enum and type alias symbols appear in hierarchical mode

### DIFF
--- a/src/serverprotocol/PasLS.Symbols.pas
+++ b/src/serverprotocol/PasLS.Symbols.pas
@@ -129,6 +129,8 @@ type
     function AddStruct(Node: TCodeTreeNode; const Name: String): TSymbol;
     function AddEnum(Node: TCodeTreeNode; const Name: String): TSymbol;
     function AddTypeAlias(Node: TCodeTreeNode; const Name: String): TSymbol;
+    function AddConstant(Node: TCodeTreeNode; const Name: String): TSymbol;
+    function AddVariable(Node: TCodeTreeNode; const Name: String): TSymbol;
     function AddProperty(Node: TCodeTreeNode; const AClassName, APropertyName: String): TSymbol;
     function AddField(Node: TCodeTreeNode; const AClassName, AFieldName: String): TSymbol;
     // Add nested function as child of parent
@@ -700,6 +702,54 @@ begin
         SetNodeRange(TypeSymbol, Node);
         // Also add to flat symbol list for database/workspace symbol
         Result := AddFlatSymbol(Node, Name, TSymbolKind._TypeParameter);
+      end;
+  end;
+end;
+
+function TSymbolBuilder.AddConstant(Node: TCodeTreeNode; const Name: String): TSymbol;
+var
+  ConstSymbol: TDocumentSymbolEx;
+begin
+  case FMode of
+    smFlat:
+      begin
+        // Flat mode: add constant to Entry.Symbols
+        Result := AddFlatSymbol(Node, Name, TSymbolKind._Constant);
+      end;
+
+    smHierarchical:
+      begin
+        // Hierarchical mode: Add constant to current container
+        ConstSymbol := TDocumentSymbolEx.Create(GetCurrentContainer);
+        ConstSymbol.name := Name;
+        ConstSymbol.kind := TSymbolKind._Constant;
+        SetNodeRange(ConstSymbol, Node);
+        // Also add to flat symbol list for database/workspace symbol
+        Result := AddFlatSymbol(Node, Name, TSymbolKind._Constant);
+      end;
+  end;
+end;
+
+function TSymbolBuilder.AddVariable(Node: TCodeTreeNode; const Name: String): TSymbol;
+var
+  VarSymbol: TDocumentSymbolEx;
+begin
+  case FMode of
+    smFlat:
+      begin
+        // Flat mode: add variable to Entry.Symbols
+        Result := AddFlatSymbol(Node, Name, TSymbolKind._Variable);
+      end;
+
+    smHierarchical:
+      begin
+        // Hierarchical mode: Add variable to current container
+        VarSymbol := TDocumentSymbolEx.Create(GetCurrentContainer);
+        VarSymbol.name := Name;
+        VarSymbol.kind := TSymbolKind._Variable;
+        SetNodeRange(VarSymbol, Node);
+        // Also add to flat symbol list for database/workspace symbol
+        Result := AddFlatSymbol(Node, Name, TSymbolKind._Variable);
       end;
   end;
 end;
@@ -1339,8 +1389,9 @@ var
   Symbol, MethodSymbol, LastClassSymbol: TSymbol;
   Child: TCodeTreeNode;
   Scanner: TLinkScanner;
-  LinkIndex: Integer;
-  IsImplementation:Boolean;
+  LinkIndex, i: Integer;
+  IsImplementation: Boolean;
+  ConstName, VarName: String;
 begin
   IsImplementation:=(Node.Parent<>nil) and  (Node.Parent.Desc=ctnImplementation);
   LastClassSymbol:=nil;
@@ -1395,20 +1446,43 @@ begin
 
       case Node.Desc of
 
+        ctnConstSection:
+          begin
+            Inc(IndentLevel);
+            Child := Node.FirstChild;
+            while Child <> nil do
+              begin
+                if Child.Desc = ctnConstDefinition then
+                  begin
+                    ConstName := GetIdentifierAtPos(Tool, Child.StartPos, true, true);
+                    Builder.AddConstant(Child, ConstName);
+                    PrintNodeDebug(Child);
+                  end;
+                Child := Child.NextBrother;
+              end;
+            Dec(IndentLevel);
+          end;
 
-        // todo: make constants an option?
-        //ctnConstSection:
-        //  begin
-        //    Inc(IndentLevel);
-        //    Child := Node.FirstChild;
-        //    while Child <> nil do
-        //      begin
-        //        AddSymbol(Child, TSymbolKind._Constant);
-        //        PrintNodeDebug(Child);
-        //        Child := Child.NextBrother;
-        //      end;
-        //    Dec(IndentLevel);
-        //  end;
+        ctnVarSection:
+          begin
+            Inc(IndentLevel);
+            Child := Node.FirstChild;
+            while Child <> nil do
+              begin
+                if Child.Desc = ctnVarDefinition then
+                  begin
+                    VarName := GetIdentifierAtPos(Tool, Child.StartPos, true, true);
+                    // Remove trailing colon if present (similar to field names)
+                    i := Pos(':', VarName);
+                    if i > 0 then
+                      VarName := Copy(VarName, 1, i - 1);
+                    Builder.AddVariable(Child, VarName);
+                    PrintNodeDebug(Child);
+                  end;
+                Child := Child.NextBrother;
+              end;
+            Dec(IndentLevel);
+          end;
 
         ctnTypeSection:
           begin

--- a/src/serverprotocol/PasLS.Symbols.pas
+++ b/src/serverprotocol/PasLS.Symbols.pas
@@ -127,6 +127,8 @@ type
     function AddMethod(Node: TCodeTreeNode; const AClassName, AMethodName: String): TSymbol;
     function AddGlobalFunction(Node: TCodeTreeNode; const Name: String): TSymbol;
     function AddStruct(Node: TCodeTreeNode; const Name: String): TSymbol;
+    function AddEnum(Node: TCodeTreeNode; const Name: String): TSymbol;
+    function AddTypeAlias(Node: TCodeTreeNode; const Name: String): TSymbol;
     function AddProperty(Node: TCodeTreeNode; const AClassName, APropertyName: String): TSymbol;
     function AddField(Node: TCodeTreeNode; const AClassName, AFieldName: String): TSymbol;
     // Add nested function as child of parent
@@ -654,6 +656,54 @@ begin
   end;
 end;
 
+function TSymbolBuilder.AddEnum(Node: TCodeTreeNode; const Name: String): TSymbol;
+var
+  EnumSymbol: TDocumentSymbolEx;
+begin
+  case FMode of
+    smFlat:
+      begin
+        // Flat mode: add enum to Entry.Symbols
+        Result := AddFlatSymbol(Node, Name, TSymbolKind._Enum);
+      end;
+
+    smHierarchical:
+      begin
+        // Hierarchical mode: Add enum to current container
+        EnumSymbol := TDocumentSymbolEx.Create(GetCurrentContainer);
+        EnumSymbol.name := Name;
+        EnumSymbol.kind := TSymbolKind._Enum;
+        SetNodeRange(EnumSymbol, Node);
+        // Also add to flat symbol list for database/workspace symbol
+        Result := AddFlatSymbol(Node, Name, TSymbolKind._Enum);
+      end;
+  end;
+end;
+
+function TSymbolBuilder.AddTypeAlias(Node: TCodeTreeNode; const Name: String): TSymbol;
+var
+  TypeSymbol: TDocumentSymbolEx;
+begin
+  case FMode of
+    smFlat:
+      begin
+        // Flat mode: add type alias to Entry.Symbols
+        Result := AddFlatSymbol(Node, Name, TSymbolKind._TypeParameter);
+      end;
+
+    smHierarchical:
+      begin
+        // Hierarchical mode: Add type alias to current container
+        TypeSymbol := TDocumentSymbolEx.Create(GetCurrentContainer);
+        TypeSymbol.name := Name;
+        TypeSymbol.kind := TSymbolKind._TypeParameter;
+        SetNodeRange(TypeSymbol, Node);
+        // Also add to flat symbol list for database/workspace symbol
+        Result := AddFlatSymbol(Node, Name, TSymbolKind._TypeParameter);
+      end;
+  end;
+end;
+
 function TSymbolBuilder.AddProperty(Node: TCodeTreeNode; const AClassName, APropertyName: String): TSymbol;
 var
   ClassSymbol: TDocumentSymbolEx;
@@ -1163,7 +1213,8 @@ begin
           end;
         ctnEnumerationType:
           begin
-            AddSymbol(TypeDefNode, TSymbolKind._Enum);
+            TypeName := CleanTypeName(GetIdentifierAtPos(Tool, TypeDefNode.StartPos, true, true));
+            Builder.AddEnum(TypeDefNode, TypeName);
             Child := Node.FirstChild;
             while Child <> nil do
               begin
@@ -1175,7 +1226,8 @@ begin
           end;
         otherwise
           begin
-            AddSymbol(TypeDefNode, TSymbolKind._TypeParameter);
+            TypeName := CleanTypeName(GetIdentifierAtPos(Tool, TypeDefNode.StartPos, true, true));
+            Builder.AddTypeAlias(TypeDefNode, TypeName);
           end;
       end;
 

--- a/src/tests/Tests.DocumentSymbol.pas
+++ b/src/tests/Tests.DocumentSymbol.pas
@@ -36,6 +36,10 @@ type
     procedure TestMethodSelectionRangePointsToName;
     procedure TestHierarchicalModeFullValidation;
     procedure TestFlatModeFullValidation;
+    procedure TestEnumSymbolsHierarchical;
+    procedure TestEnumSymbolsFlat;
+    procedure TestTypeAliasSymbolsHierarchical;
+    procedure TestTypeAliasSymbolsFlat;
   end;
 
 implementation
@@ -70,6 +74,59 @@ const
     'function TUser.GetFullName: String;' + LineEnding +
     'begin' + LineEnding +
     '  Result := FName;' + LineEnding +
+    'end;' + LineEnding +
+    '' + LineEnding +
+    'end.';
+
+  // Test file with enum type for testing enum symbol extraction
+  TEST_UNIT_WITH_ENUM =
+    'unit TestEnumUnit;' + LineEnding +
+    '' + LineEnding +
+    '{$mode objfpc}{$H+}' + LineEnding +
+    '' + LineEnding +
+    'interface' + LineEnding +
+    '' + LineEnding +
+    'type' + LineEnding +
+    '  TColor = (clRed, clGreen, clBlue);' + LineEnding +
+    '  TStatus = (stPending, stActive, stDone);' + LineEnding +
+    '' + LineEnding +
+    '  TMyClass = class' + LineEnding +
+    '  public' + LineEnding +
+    '    procedure DoSomething;' + LineEnding +
+    '  end;' + LineEnding +
+    '' + LineEnding +
+    'implementation' + LineEnding +
+    '' + LineEnding +
+    'procedure TMyClass.DoSomething;' + LineEnding +
+    'begin' + LineEnding +
+    'end;' + LineEnding +
+    '' + LineEnding +
+    'end.';
+
+  // Test file with type aliases for testing type alias symbol extraction
+  TEST_UNIT_WITH_TYPE_ALIAS =
+    'unit TestTypeAliasUnit;' + LineEnding +
+    '' + LineEnding +
+    '{$mode objfpc}{$H+}' + LineEnding +
+    '' + LineEnding +
+    'interface' + LineEnding +
+    '' + LineEnding +
+    'type' + LineEnding +
+    '  TMyInteger = Integer;' + LineEnding +
+    '  PInteger = ^Integer;' + LineEnding +
+    '  TMySet = set of Byte;' + LineEnding +
+    '  TMyProc = procedure(X: Integer);' + LineEnding +
+    '  TMyArray = array[0..10] of Integer;' + LineEnding +
+    '' + LineEnding +
+    '  TMyClass = class' + LineEnding +
+    '  public' + LineEnding +
+    '    procedure DoSomething;' + LineEnding +
+    '  end;' + LineEnding +
+    '' + LineEnding +
+    'implementation' + LineEnding +
+    '' + LineEnding +
+    'procedure TMyClass.DoSomething;' + LineEnding +
+    'begin' + LineEnding +
     'end;' + LineEnding +
     '' + LineEnding +
     'end.';
@@ -1506,6 +1563,156 @@ begin
   finally
     JSONData.Free;
   end;
+end;
+
+procedure TTestDocumentSymbol.TestEnumSymbolsHierarchical;
+var
+  RawJSON: String;
+begin
+  // This test verifies that enum types appear in hierarchical mode
+  // (Bug: enums were bypassing TSymbolBuilder, missing from hierarchical output)
+
+  // Set hierarchical mode
+  SetClientCapabilities(True);
+
+  // Create test file with enum types
+  CreateTestFile(TEST_UNIT_WITH_ENUM);
+
+  // Load code buffer
+  FTestCode := CodeToolBoss.LoadFile(FTestFile, True, False);
+  AssertNotNull('Code buffer should be loaded', FTestCode);
+
+  // Use SymbolManager to reload and extract symbols
+  SymbolManager.Reload(FTestCode, True);
+
+  // Get the raw JSON from SymbolManager
+  RawJSON := SymbolManager.FindDocumentSymbols(FTestFile).AsJSON;
+
+  // Verify we extracted symbols
+  AssertTrue('Should have extracted symbols', RawJSON <> '');
+
+  // Verify enum symbols are present (kind 10 = Enum)
+  AssertTrue('JSON should contain TColor enum', Pos('"TColor"', RawJSON) > 0);
+  AssertTrue('JSON should contain TStatus enum', Pos('"TStatus"', RawJSON) > 0);
+  AssertTrue('Should have Enum kind (10)', Pos('"kind" : 10', RawJSON) > 0);
+
+  // Verify hierarchical structure (children array should exist)
+  AssertTrue('Should have children in hierarchical mode', Pos('"children"', RawJSON) > 0);
+
+  // Verify class also exists (to confirm other symbols still work)
+  AssertTrue('JSON should contain TMyClass', Pos('"TMyClass"', RawJSON) > 0);
+end;
+
+procedure TTestDocumentSymbol.TestEnumSymbolsFlat;
+var
+  RawJSON: String;
+begin
+  // This test verifies that enum types appear in flat mode
+
+  // Set flat mode
+  SetClientCapabilities(False);
+
+  // Create test file with enum types
+  CreateTestFile(TEST_UNIT_WITH_ENUM);
+
+  // Load code buffer
+  FTestCode := CodeToolBoss.LoadFile(FTestFile, True, False);
+  AssertNotNull('Code buffer should be loaded', FTestCode);
+
+  // Use SymbolManager to reload and extract symbols
+  SymbolManager.Reload(FTestCode, True);
+
+  // Get the raw JSON from SymbolManager
+  RawJSON := SymbolManager.FindDocumentSymbols(FTestFile).AsJSON;
+
+  // Verify we extracted symbols
+  AssertTrue('Should have extracted symbols', RawJSON <> '');
+
+  // Verify enum symbols are present (kind 10 = Enum)
+  AssertTrue('JSON should contain TColor enum', Pos('"TColor"', RawJSON) > 0);
+  AssertTrue('JSON should contain TStatus enum', Pos('"TStatus"', RawJSON) > 0);
+  AssertTrue('Should have Enum kind (10)', Pos('"kind" : 10', RawJSON) > 0);
+
+  // Verify class also exists (to confirm other symbols still work)
+  AssertTrue('JSON should contain TMyClass', Pos('"TMyClass"', RawJSON) > 0);
+end;
+
+procedure TTestDocumentSymbol.TestTypeAliasSymbolsHierarchical;
+var
+  RawJSON: String;
+begin
+  // This test verifies that type aliases appear in hierarchical mode
+  // (Bug: type aliases were bypassing TSymbolBuilder, missing from hierarchical output)
+
+  // Set hierarchical mode
+  SetClientCapabilities(True);
+
+  // Create test file with type alias types
+  CreateTestFile(TEST_UNIT_WITH_TYPE_ALIAS);
+
+  // Load code buffer
+  FTestCode := CodeToolBoss.LoadFile(FTestFile, True, False);
+  AssertNotNull('Code buffer should be loaded', FTestCode);
+
+  // Use SymbolManager to reload and extract symbols
+  SymbolManager.Reload(FTestCode, True);
+
+  // Get the raw JSON from SymbolManager
+  RawJSON := SymbolManager.FindDocumentSymbols(FTestFile).AsJSON;
+
+  // Verify we extracted symbols
+  AssertTrue('Should have extracted symbols', RawJSON <> '');
+
+  // Verify type alias symbols are present (kind 26 = TypeParameter)
+  AssertTrue('JSON should contain TMyInteger', Pos('"TMyInteger"', RawJSON) > 0);
+  AssertTrue('JSON should contain PInteger', Pos('"PInteger"', RawJSON) > 0);
+  AssertTrue('JSON should contain TMySet', Pos('"TMySet"', RawJSON) > 0);
+  AssertTrue('JSON should contain TMyProc', Pos('"TMyProc"', RawJSON) > 0);
+  AssertTrue('JSON should contain TMyArray', Pos('"TMyArray"', RawJSON) > 0);
+  AssertTrue('Should have TypeParameter kind (26)', Pos('"kind" : 26', RawJSON) > 0);
+
+  // Verify hierarchical structure (children array should exist)
+  AssertTrue('Should have children in hierarchical mode', Pos('"children"', RawJSON) > 0);
+
+  // Verify class also exists (to confirm other symbols still work)
+  AssertTrue('JSON should contain TMyClass', Pos('"TMyClass"', RawJSON) > 0);
+end;
+
+procedure TTestDocumentSymbol.TestTypeAliasSymbolsFlat;
+var
+  RawJSON: String;
+begin
+  // This test verifies that type aliases appear in flat mode
+
+  // Set flat mode
+  SetClientCapabilities(False);
+
+  // Create test file with type alias types
+  CreateTestFile(TEST_UNIT_WITH_TYPE_ALIAS);
+
+  // Load code buffer
+  FTestCode := CodeToolBoss.LoadFile(FTestFile, True, False);
+  AssertNotNull('Code buffer should be loaded', FTestCode);
+
+  // Use SymbolManager to reload and extract symbols
+  SymbolManager.Reload(FTestCode, True);
+
+  // Get the raw JSON from SymbolManager
+  RawJSON := SymbolManager.FindDocumentSymbols(FTestFile).AsJSON;
+
+  // Verify we extracted symbols
+  AssertTrue('Should have extracted symbols', RawJSON <> '');
+
+  // Verify type alias symbols are present (kind 26 = TypeParameter)
+  AssertTrue('JSON should contain TMyInteger', Pos('"TMyInteger"', RawJSON) > 0);
+  AssertTrue('JSON should contain PInteger', Pos('"PInteger"', RawJSON) > 0);
+  AssertTrue('JSON should contain TMySet', Pos('"TMySet"', RawJSON) > 0);
+  AssertTrue('JSON should contain TMyProc', Pos('"TMyProc"', RawJSON) > 0);
+  AssertTrue('JSON should contain TMyArray', Pos('"TMyArray"', RawJSON) > 0);
+  AssertTrue('Should have TypeParameter kind (26)', Pos('"kind" : 26', RawJSON) > 0);
+
+  // Verify class also exists (to confirm other symbols still work)
+  AssertTrue('JSON should contain TMyClass', Pos('"TMyClass"', RawJSON) > 0);
 end;
 
 initialization

--- a/src/tests/Tests.DocumentSymbol.pas
+++ b/src/tests/Tests.DocumentSymbol.pas
@@ -40,6 +40,10 @@ type
     procedure TestEnumSymbolsFlat;
     procedure TestTypeAliasSymbolsHierarchical;
     procedure TestTypeAliasSymbolsFlat;
+    procedure TestConstantSymbolsHierarchical;
+    procedure TestConstantSymbolsFlat;
+    procedure TestGlobalVarSymbolsHierarchical;
+    procedure TestGlobalVarSymbolsFlat;
   end;
 
 implementation
@@ -124,6 +128,65 @@ const
     '  end;' + LineEnding +
     '' + LineEnding +
     'implementation' + LineEnding +
+    '' + LineEnding +
+    'procedure TMyClass.DoSomething;' + LineEnding +
+    'begin' + LineEnding +
+    'end;' + LineEnding +
+    '' + LineEnding +
+    'end.';
+
+  // Test file with constants for testing constant symbol extraction
+  TEST_UNIT_WITH_CONSTANTS =
+    'unit TestConstUnit;' + LineEnding +
+    '' + LineEnding +
+    '{$mode objfpc}{$H+}' + LineEnding +
+    '' + LineEnding +
+    'interface' + LineEnding +
+    '' + LineEnding +
+    'const' + LineEnding +
+    '  MAX_SIZE = 100;' + LineEnding +
+    '  DEFAULT_NAME = ''Test'';' + LineEnding +
+    '  PI_VALUE = 3.14159;' + LineEnding +
+    '' + LineEnding +
+    'type' + LineEnding +
+    '  TMyClass = class' + LineEnding +
+    '  public' + LineEnding +
+    '    procedure DoSomething;' + LineEnding +
+    '  end;' + LineEnding +
+    '' + LineEnding +
+    'implementation' + LineEnding +
+    '' + LineEnding +
+    'const' + LineEnding +
+    '  IMPL_CONST = 42;' + LineEnding +
+    '' + LineEnding +
+    'procedure TMyClass.DoSomething;' + LineEnding +
+    'begin' + LineEnding +
+    'end;' + LineEnding +
+    '' + LineEnding +
+    'end.';
+
+  // Test file with global variables for testing variable symbol extraction
+  TEST_UNIT_WITH_GLOBAL_VARS =
+    'unit TestVarUnit;' + LineEnding +
+    '' + LineEnding +
+    '{$mode objfpc}{$H+}' + LineEnding +
+    '' + LineEnding +
+    'interface' + LineEnding +
+    '' + LineEnding +
+    'var' + LineEnding +
+    '  GlobalCounter: Integer;' + LineEnding +
+    '  AppName: String;' + LineEnding +
+    '' + LineEnding +
+    'type' + LineEnding +
+    '  TMyClass = class' + LineEnding +
+    '  public' + LineEnding +
+    '    procedure DoSomething;' + LineEnding +
+    '  end;' + LineEnding +
+    '' + LineEnding +
+    'implementation' + LineEnding +
+    '' + LineEnding +
+    'var' + LineEnding +
+    '  ImplVar: Integer;' + LineEnding +
     '' + LineEnding +
     'procedure TMyClass.DoSomething;' + LineEnding +
     'begin' + LineEnding +
@@ -1710,6 +1773,154 @@ begin
   AssertTrue('JSON should contain TMyProc', Pos('"TMyProc"', RawJSON) > 0);
   AssertTrue('JSON should contain TMyArray', Pos('"TMyArray"', RawJSON) > 0);
   AssertTrue('Should have TypeParameter kind (26)', Pos('"kind" : 26', RawJSON) > 0);
+
+  // Verify class also exists (to confirm other symbols still work)
+  AssertTrue('JSON should contain TMyClass', Pos('"TMyClass"', RawJSON) > 0);
+end;
+
+procedure TTestDocumentSymbol.TestConstantSymbolsHierarchical;
+var
+  RawJSON: String;
+begin
+  // This test verifies that constants appear in hierarchical mode
+
+  // Set hierarchical mode
+  SetClientCapabilities(True);
+
+  // Create test file with constants
+  CreateTestFile(TEST_UNIT_WITH_CONSTANTS);
+
+  // Load code buffer
+  FTestCode := CodeToolBoss.LoadFile(FTestFile, True, False);
+  AssertNotNull('Code buffer should be loaded', FTestCode);
+
+  // Use SymbolManager to reload and extract symbols
+  SymbolManager.Reload(FTestCode, True);
+
+  // Get the raw JSON from SymbolManager
+  RawJSON := SymbolManager.FindDocumentSymbols(FTestFile).AsJSON;
+
+  // Verify we extracted symbols
+  AssertTrue('Should have extracted symbols', RawJSON <> '');
+
+  // Verify constant symbols are present (kind 14 = Constant)
+  AssertTrue('JSON should contain MAX_SIZE', Pos('"MAX_SIZE"', RawJSON) > 0);
+  AssertTrue('JSON should contain DEFAULT_NAME', Pos('"DEFAULT_NAME"', RawJSON) > 0);
+  AssertTrue('JSON should contain PI_VALUE', Pos('"PI_VALUE"', RawJSON) > 0);
+  AssertTrue('JSON should contain IMPL_CONST', Pos('"IMPL_CONST"', RawJSON) > 0);
+  AssertTrue('Should have Constant kind (14)', Pos('"kind" : 14', RawJSON) > 0);
+
+  // Verify hierarchical structure (children array should exist)
+  AssertTrue('Should have children in hierarchical mode', Pos('"children"', RawJSON) > 0);
+
+  // Verify class also exists (to confirm other symbols still work)
+  AssertTrue('JSON should contain TMyClass', Pos('"TMyClass"', RawJSON) > 0);
+end;
+
+procedure TTestDocumentSymbol.TestConstantSymbolsFlat;
+var
+  RawJSON: String;
+begin
+  // This test verifies that constants appear in flat mode
+
+  // Set flat mode
+  SetClientCapabilities(False);
+
+  // Create test file with constants
+  CreateTestFile(TEST_UNIT_WITH_CONSTANTS);
+
+  // Load code buffer
+  FTestCode := CodeToolBoss.LoadFile(FTestFile, True, False);
+  AssertNotNull('Code buffer should be loaded', FTestCode);
+
+  // Use SymbolManager to reload and extract symbols
+  SymbolManager.Reload(FTestCode, True);
+
+  // Get the raw JSON from SymbolManager
+  RawJSON := SymbolManager.FindDocumentSymbols(FTestFile).AsJSON;
+
+  // Verify we extracted symbols
+  AssertTrue('Should have extracted symbols', RawJSON <> '');
+
+  // Verify constant symbols are present (kind 14 = Constant)
+  AssertTrue('JSON should contain MAX_SIZE', Pos('"MAX_SIZE"', RawJSON) > 0);
+  AssertTrue('JSON should contain DEFAULT_NAME', Pos('"DEFAULT_NAME"', RawJSON) > 0);
+  AssertTrue('JSON should contain PI_VALUE', Pos('"PI_VALUE"', RawJSON) > 0);
+  AssertTrue('JSON should contain IMPL_CONST', Pos('"IMPL_CONST"', RawJSON) > 0);
+  AssertTrue('Should have Constant kind (14)', Pos('"kind" : 14', RawJSON) > 0);
+
+  // Verify class also exists (to confirm other symbols still work)
+  AssertTrue('JSON should contain TMyClass', Pos('"TMyClass"', RawJSON) > 0);
+end;
+
+procedure TTestDocumentSymbol.TestGlobalVarSymbolsHierarchical;
+var
+  RawJSON: String;
+begin
+  // This test verifies that global variables appear in hierarchical mode
+
+  // Set hierarchical mode
+  SetClientCapabilities(True);
+
+  // Create test file with global variables
+  CreateTestFile(TEST_UNIT_WITH_GLOBAL_VARS);
+
+  // Load code buffer
+  FTestCode := CodeToolBoss.LoadFile(FTestFile, True, False);
+  AssertNotNull('Code buffer should be loaded', FTestCode);
+
+  // Use SymbolManager to reload and extract symbols
+  SymbolManager.Reload(FTestCode, True);
+
+  // Get the raw JSON from SymbolManager
+  RawJSON := SymbolManager.FindDocumentSymbols(FTestFile).AsJSON;
+
+  // Verify we extracted symbols
+  AssertTrue('Should have extracted symbols', RawJSON <> '');
+
+  // Verify variable symbols are present (kind 13 = Variable)
+  AssertTrue('JSON should contain GlobalCounter', Pos('"GlobalCounter"', RawJSON) > 0);
+  AssertTrue('JSON should contain AppName', Pos('"AppName"', RawJSON) > 0);
+  AssertTrue('JSON should contain ImplVar', Pos('"ImplVar"', RawJSON) > 0);
+  AssertTrue('Should have Variable kind (13)', Pos('"kind" : 13', RawJSON) > 0);
+
+  // Verify hierarchical structure (children array should exist)
+  AssertTrue('Should have children in hierarchical mode', Pos('"children"', RawJSON) > 0);
+
+  // Verify class also exists (to confirm other symbols still work)
+  AssertTrue('JSON should contain TMyClass', Pos('"TMyClass"', RawJSON) > 0);
+end;
+
+procedure TTestDocumentSymbol.TestGlobalVarSymbolsFlat;
+var
+  RawJSON: String;
+begin
+  // This test verifies that global variables appear in flat mode
+
+  // Set flat mode
+  SetClientCapabilities(False);
+
+  // Create test file with global variables
+  CreateTestFile(TEST_UNIT_WITH_GLOBAL_VARS);
+
+  // Load code buffer
+  FTestCode := CodeToolBoss.LoadFile(FTestFile, True, False);
+  AssertNotNull('Code buffer should be loaded', FTestCode);
+
+  // Use SymbolManager to reload and extract symbols
+  SymbolManager.Reload(FTestCode, True);
+
+  // Get the raw JSON from SymbolManager
+  RawJSON := SymbolManager.FindDocumentSymbols(FTestFile).AsJSON;
+
+  // Verify we extracted symbols
+  AssertTrue('Should have extracted symbols', RawJSON <> '');
+
+  // Verify variable symbols are present (kind 13 = Variable)
+  AssertTrue('JSON should contain GlobalCounter', Pos('"GlobalCounter"', RawJSON) > 0);
+  AssertTrue('JSON should contain AppName', Pos('"AppName"', RawJSON) > 0);
+  AssertTrue('JSON should contain ImplVar', Pos('"ImplVar"', RawJSON) > 0);
+  AssertTrue('Should have Variable kind (13)', Pos('"kind" : 13', RawJSON) > 0);
 
   // Verify class also exists (to confirm other symbols still work)
   AssertTrue('JSON should contain TMyClass', Pos('"TMyClass"', RawJSON) > 0);


### PR DESCRIPTION
## Summary

- Enums and type aliases were bypassing TSymbolBuilder, causing them to be missing from hierarchical mode (VSCode) while appearing in flat mode (Sublime Text)
- Added `AddEnum` and `AddTypeAlias` methods to TSymbolBuilder that properly add symbols to both the hierarchy and flat list
- Updated `ExtractTypeDefinition` to use these new builder methods

## Test plan

- [x] Added `TestEnumSymbolsHierarchical` - verifies enums appear in hierarchical mode
- [x] Added `TestEnumSymbolsFlat` - verifies enums appear in flat mode
- [x] Added `TestTypeAliasSymbolsHierarchical` - verifies type aliases appear in hierarchical mode
- [x] Added `TestTypeAliasSymbolsFlat` - verifies type aliases appear in flat mode
- [x] All 58 tests pass