### PR TITLE
feat: add class constant symbol extraction

### DIFF
--- a/src/serverprotocol/PasLS.Symbols.pas
+++ b/src/serverprotocol/PasLS.Symbols.pas
@@ -133,6 +133,7 @@ type
     function AddVariable(Node: TCodeTreeNode; const Name: String): TSymbol;
     function AddProperty(Node: TCodeTreeNode; const AClassName, APropertyName: String): TSymbol;
     function AddField(Node: TCodeTreeNode; const AClassName, AFieldName: String): TSymbol;
+    function AddClassConstant(Node: TCodeTreeNode; const AClassName, AConstName: String): TSymbol;
     // Add nested function as child of parent
     function AddNestedFunction(Parent: TDocumentSymbolEx; Node: TCodeTreeNode; const Name, ParentPath: String): TDocumentSymbolEx;
 
@@ -812,6 +813,36 @@ begin
   end;
 end;
 
+function TSymbolBuilder.AddClassConstant(Node: TCodeTreeNode;
+  const AClassName, AConstName: String): TSymbol;
+var
+  ClassSymbol: TDocumentSymbolEx;
+  ConstSymbol: TDocumentSymbolEx;
+begin
+  case FMode of
+    smFlat:
+      begin
+        // Flat mode: Class.Const naming, no containerName (Lazarus style)
+        Result := AddFlatSymbol(Node, AClassName + '.' + AConstName, TSymbolKind._Constant);
+      end;
+
+    smHierarchical:
+      begin
+        // Hierarchical mode: add constant to class's children
+        ClassSymbol := FindOrCreateClass(AClassName, Node);
+        if ClassSymbol <> nil then
+          begin
+            ConstSymbol := TDocumentSymbolEx.Create(ClassSymbol.children);
+            ConstSymbol.name := AConstName;
+            ConstSymbol.kind := TSymbolKind._Constant;
+            SetNodeRange(ConstSymbol, Node);
+          end;
+        // Add to flat symbol list with LSP semantics
+        Result := AddFlatSymbol(Node, AConstName, TSymbolKind._Constant, AClassName);
+      end;
+  end;
+end;
+
 function TSymbolBuilder.AddNestedFunction(Parent: TDocumentSymbolEx; Node: TCodeTreeNode; const Name, ParentPath: String): TDocumentSymbolEx;
 var
   FullPath: String;
@@ -1111,7 +1142,7 @@ procedure TSymbolExtractor.ExtractObjCClassMethods(ClassNode, Node: TCodeTreeNod
 var
   Child: TCodeTreeNode;
   ExternalClass: boolean = false;
-  TypeName, PropertyName, FieldName: String;
+  TypeName, PropertyName, FieldName, ConstName: String;
   i: Integer;
 begin
   while Node <> nil do
@@ -1163,6 +1194,24 @@ begin
             if i > 0 then
               FieldName := Copy(FieldName, 1, i - 1);
             Builder.AddField(Node, TypeName, FieldName);
+          end;
+        ctnConstSection:
+          begin
+            // Handle class constants (e.g., "public const MY_CONST = 42;")
+            Inc(IndentLevel);
+            TypeName := GetIdentifierAtPos(Tool, ClassNode.StartPos, true, true);
+            Child := Node.FirstChild;
+            while Child <> nil do
+              begin
+                if Child.Desc = ctnConstDefinition then
+                  begin
+                    ConstName := GetIdentifierAtPos(Tool, Child.StartPos, true, true);
+                    Builder.AddClassConstant(Child, TypeName, ConstName);
+                    PrintNodeDebug(Child);
+                  end;
+                Child := Child.NextBrother;
+              end;
+            Dec(IndentLevel);
           end;
         ctnClassPublic,ctnClassPublished,ctnClassPrivate,ctnClassProtected,
         ctnClassRequired,ctnClassOptional:

--- a/src/tests/Tests.DocumentSymbol.pas
+++ b/src/tests/Tests.DocumentSymbol.pas
@@ -44,6 +44,8 @@ type
     procedure TestConstantSymbolsFlat;
     procedure TestGlobalVarSymbolsHierarchical;
     procedure TestGlobalVarSymbolsFlat;
+    procedure TestClassConstantSymbolsHierarchical;
+    procedure TestClassConstantSymbolsFlat;
   end;
 
 implementation
@@ -187,6 +189,32 @@ const
     '' + LineEnding +
     'var' + LineEnding +
     '  ImplVar: Integer;' + LineEnding +
+    '' + LineEnding +
+    'procedure TMyClass.DoSomething;' + LineEnding +
+    'begin' + LineEnding +
+    'end;' + LineEnding +
+    '' + LineEnding +
+    'end.';
+
+  // Test file with class constants for testing class constant symbol extraction
+  TEST_UNIT_WITH_CLASS_CONST =
+    'unit TestClassConstUnit;' + LineEnding +
+    '' + LineEnding +
+    '{$mode objfpc}{$H+}' + LineEnding +
+    '' + LineEnding +
+    'interface' + LineEnding +
+    '' + LineEnding +
+    'type' + LineEnding +
+    '  TMyClass = class' + LineEnding +
+    '  public const' + LineEnding +
+    '    MY_CONST = 42;' + LineEnding +
+    '    STR_CONST = ''hello'';' + LineEnding +
+    '  public' + LineEnding +
+    '    FValue: Integer;' + LineEnding +
+    '    procedure DoSomething;' + LineEnding +
+    '  end;' + LineEnding +
+    '' + LineEnding +
+    'implementation' + LineEnding +
     '' + LineEnding +
     'procedure TMyClass.DoSomething;' + LineEnding +
     'begin' + LineEnding +
@@ -1923,6 +1951,83 @@ begin
   AssertTrue('Should have Variable kind (13)', Pos('"kind" : 13', RawJSON) > 0);
 
   // Verify class also exists (to confirm other symbols still work)
+  AssertTrue('JSON should contain TMyClass', Pos('"TMyClass"', RawJSON) > 0);
+end;
+
+procedure TTestDocumentSymbol.TestClassConstantSymbolsHierarchical;
+var
+  RawJSON: String;
+begin
+  // This test verifies that class constants appear in hierarchical mode
+
+  // Set hierarchical mode
+  SetClientCapabilities(True);
+
+  // Create test file with class constants
+  CreateTestFile(TEST_UNIT_WITH_CLASS_CONST);
+
+  // Load code buffer
+  FTestCode := CodeToolBoss.LoadFile(FTestFile, True, False);
+  AssertNotNull('Code buffer should be loaded', FTestCode);
+
+  // Use SymbolManager to reload and extract symbols
+  SymbolManager.Reload(FTestCode, True);
+
+  // Get the raw JSON from SymbolManager
+  RawJSON := SymbolManager.FindDocumentSymbols(FTestFile).AsJSON;
+
+  // Verify we extracted symbols
+  AssertTrue('Should have extracted symbols', RawJSON <> '');
+
+  // Verify class constant symbols are present (kind 14 = Constant)
+  AssertTrue('JSON should contain MY_CONST', Pos('"MY_CONST"', RawJSON) > 0);
+  AssertTrue('JSON should contain STR_CONST', Pos('"STR_CONST"', RawJSON) > 0);
+  AssertTrue('Should have Constant kind (14)', Pos('"kind" : 14', RawJSON) > 0);
+
+  // Verify hierarchical structure - constants should be children of TMyClass
+  AssertTrue('Should have children in hierarchical mode', Pos('"children"', RawJSON) > 0);
+
+  // Verify class and other members also exist
+  AssertTrue('JSON should contain TMyClass', Pos('"TMyClass"', RawJSON) > 0);
+  AssertTrue('JSON should contain FValue field', Pos('"FValue"', RawJSON) > 0);
+  AssertTrue('JSON should contain DoSomething method', Pos('"DoSomething"', RawJSON) > 0);
+end;
+
+procedure TTestDocumentSymbol.TestClassConstantSymbolsFlat;
+var
+  RawJSON: String;
+begin
+  // This test verifies that class constants appear in flat mode with Class.Const naming
+
+  // Set flat mode
+  SetClientCapabilities(False);
+
+  // Create test file with class constants
+  CreateTestFile(TEST_UNIT_WITH_CLASS_CONST);
+
+  // Load code buffer
+  FTestCode := CodeToolBoss.LoadFile(FTestFile, True, False);
+  AssertNotNull('Code buffer should be loaded', FTestCode);
+
+  // Use SymbolManager to reload and extract symbols
+  SymbolManager.Reload(FTestCode, True);
+
+  // Get the raw JSON from SymbolManager
+  RawJSON := SymbolManager.FindDocumentSymbols(FTestFile).AsJSON;
+
+  // Verify we extracted symbols
+  AssertTrue('Should have extracted symbols', RawJSON <> '');
+
+  // Verify class constants use Class.Const naming format
+  AssertTrue('JSON should contain TMyClass.MY_CONST',
+    Pos('"TMyClass.MY_CONST"', RawJSON) > 0);
+  AssertTrue('JSON should contain TMyClass.STR_CONST',
+    Pos('"TMyClass.STR_CONST"', RawJSON) > 0);
+
+  // Verify kind is Constant (14)
+  AssertTrue('Should have Constant kind (14)', Pos('"kind" : 14', RawJSON) > 0);
+
+  // Verify class also exists
   AssertTrue('JSON should contain TMyClass', Pos('"TMyClass"', RawJSON) > 0);
 end;
 


### PR DESCRIPTION
## Summary

Based on Ryan's suggestion in PR #124.

- Add `AddClassConstant` method to `TSymbolBuilder` for both `smFlat` and `smHierarchical` modes
- Add `ctnConstSection` handler in `ExtractObjCClassMethods`
- Add test cases for class constants in both modes

## Details

Class constants declared with `public const`, `private const`, etc. now appear in the symbol table:

- **Flat mode**: `TMyClass.MY_CONST`
- **Hierarchical mode**: Constants as children of the class

## Test Plan

- [x] All 64 tests pass
- [x] Manual testing in editor

## Note

After this PR is merged, the refactoring work in PR #121 will begin.