### PR TITLE
feat: Add ClientFeature support for secondary text in completion items

### DIFF
--- a/src/serverprotocol/PasLS.ClientProfile.pas
+++ b/src/serverprotocol/PasLS.ClientProfile.pas
@@ -34,7 +34,8 @@ type
     cfExcludeInterfaceMethodDecls, // Don't include method/function/procedure declarations from interface section
     cfExcludeImplClassDefs,        // Don't include class definitions from implementation section
     cfNullDocumentVersion,         // Use nil instead of 0 for document version
-    cfFilterTextOnly               // Only set filterText in completion, not label
+    cfFilterTextOnly,              // Only set filterText in completion, not label
+    cfUseSecondaryText             // Use secondaryText field in completion items  
   );
   TClientFeatures = set of TClientFeature;
 
@@ -78,7 +79,8 @@ const
     'excludeInterfaceMethodDecls',
     'excludeImplClassDefs',
     'nullDocumentVersion',
-    'filterTextOnly'
+    'filterTextOnly',
+    'useSecondaryText'  
   );
 
 function TryStrToFeature(const S: string; out F: TClientFeature): Boolean;

--- a/src/serverprotocol/PasLS.Completion.pas
+++ b/src/serverprotocol/PasLS.Completion.pas
@@ -66,8 +66,8 @@ end;
 
 procedure TCompletionItemHelper.SetSecondaryText(text: string);
 begin
-  if not TClientProfile.Current.HasFeature(cfFilterTextOnly) then
-    &label := text;
+  if (not TClientProfile.Current.HasFeature(cfFilterTextOnly)) and TClientProfile.Current.HasFeature(cfUseSecondaryText) then
+    &label := &label + ' ' + text;
 end;
 
 


### PR DESCRIPTION
SetsecondaryText overrides the label, causing it to display incorrectly in VS Code. I’ve submitted this patch to try to fix the issue.

However, I wonder whether this functionality is actually needed at all?

# before
<img width="812" height="468" alt="image" src="https://github.com/user-attachments/assets/a22fb7c9-662e-465a-8543-b1b41a348a52" />

# after 

useSecondaryText is not seted

<img width="734" height="366" alt="image" src="https://github.com/user-attachments/assets/84e6a971-0ca5-47a9-b57d-bab971c4e792" />
