### PR TITLE
fix: handle null/missing params in TLSPStreaming.ToObject

### DIFF
--- a/src/protocol/LSP.Streaming.pas
+++ b/src/protocol/LSP.Streaming.pas
@@ -325,7 +325,9 @@ end;
 class function TLSPStreaming.ToObject(const JSON: TJSONData): T;
 begin
   Result := T.Create;
-  DeStreamer.JSONToObject(JSON as TJSONObject, TObject(Result));
+  // JSON-RPC 2.0 allows params to be omitted or null for certain methods
+  if Assigned(JSON) and (JSON is TJSONObject) then
+    DeStreamer.JSONToObject(JSON as TJSONObject, TObject(Result));
 end;
 
 class function TLSPStreaming.ToObject(const JSON: TJSONStringType): T;

--- a/src/tests/Tests.Streaming.pas
+++ b/src/tests/Tests.Streaming.pas
@@ -1,0 +1,87 @@
+unit Tests.Streaming;
+
+{$mode objfpc}{$H+}
+
+interface
+
+uses
+  Classes, SysUtils, fpcunit, testregistry, fpjson,
+  LSP.Streaming, LSP.General;
+
+type
+
+  { TTestLSPStreaming }
+
+  TTestLSPStreaming = class(TTestCase)
+  published
+    // Test that ToObject handles nil JSON (params omitted in JSON-RPC)
+    procedure TestToObjectWithNilJSON;
+    // Test that ToObject handles TJSONNull (params: null in JSON-RPC)
+    procedure TestToObjectWithJSONNull;
+    // Test that ToObject still works with valid TJSONObject
+    procedure TestToObjectWithValidJSONObject;
+  end;
+
+implementation
+
+type
+  TVoidParamsStreaming = specialize TLSPStreaming<TVoidParams>;
+
+{ TTestLSPStreaming }
+
+procedure TTestLSPStreaming.TestToObjectWithNilJSON;
+var
+  Params: TVoidParams;
+begin
+  // JSON-RPC 2.0 allows params to be omitted, which results in nil
+  // This should not crash, but return a default-constructed TVoidParams
+  Params := TVoidParamsStreaming.ToObject(TJSONData(nil));
+  try
+    AssertNotNull('ToObject(nil) should return valid object', Params);
+  finally
+    Params.Free;
+  end;
+end;
+
+procedure TTestLSPStreaming.TestToObjectWithJSONNull;
+var
+  Params: TVoidParams;
+  NullJSON: TJSONNull;
+begin
+  // LSP shutdown request can send "params": null
+  // This should not crash, but return a default-constructed TVoidParams
+  NullJSON := TJSONNull.Create;
+  try
+    Params := TVoidParamsStreaming.ToObject(NullJSON);
+    try
+      AssertNotNull('ToObject(TJSONNull) should return valid object', Params);
+    finally
+      Params.Free;
+    end;
+  finally
+    NullJSON.Free;
+  end;
+end;
+
+procedure TTestLSPStreaming.TestToObjectWithValidJSONObject;
+var
+  Params: TVoidParams;
+  JSONObj: TJSONObject;
+begin
+  // Normal case: valid JSON object should still work
+  JSONObj := TJSONObject.Create;
+  try
+    Params := TVoidParamsStreaming.ToObject(JSONObj);
+    try
+      AssertNotNull('ToObject(TJSONObject) should return valid object', Params);
+    finally
+      Params.Free;
+    end;
+  finally
+    JSONObj.Free;
+  end;
+end;
+
+initialization
+  RegisterTest(TTestLSPStreaming);
+end.

--- a/src/tests/testlsp.lpr
+++ b/src/tests/testlsp.lpr
@@ -5,7 +5,7 @@ program testlsp;
 uses
   Classes, consoletestrunner, Tests.Basic, Tests.DocumentSymbol,
   Tests.SublimeProfile, Tests.SymbolPersistence, Tests.WorkspaceSymbol,
-  Tests.Diagnostic, Tests.ScanExamples;
+  Tests.Diagnostic, Tests.ScanExamples, Tests.Streaming;
 
 type
 


### PR DESCRIPTION
## Summary
- Fix crash when receiving LSP requests with null or missing params (e.g., `shutdown`, `exit`)
- JSON-RPC 2.0 allows params to be omitted or set to null for certain methods

## Problem
When params is null (`"params": null`) or missing, `TLSPStreaming.ToObject` crashes with `EInvalidCast` because:
- `TJSONNull as TJSONObject` throws exception
- This breaks LSP clients that send `shutdown` without params

## Solution
Add guard check in `ToObject`:
```pascal
if Assigned(JSON) and (JSON is TJSONObject) then
  DeStreamer.JSONToObject(JSON as TJSONObject, TObject(Result));
```

## Test plan
- [x] Added 3 test cases in `Tests.Streaming.pas`
- [x] All 71 tests pass

## Related
This PR resolves [serena issue #870](https://github.com/oraios/serena/issues/870)