### PR TITLE
Fix VSCode extension trace mode

### DIFF
--- a/clients/pasls-vscode/src/extension.ts
+++ b/clients/pasls-vscode/src/extension.ts
@@ -262,7 +262,7 @@ export function activate(context: ExtensionContext) {
 		]
 	}
 
-	client = new LanguageClient('pascal-language-server', 'Pascal Language Server', serverOptions, clientOptions);
+	client = new LanguageClient('pascalLanguageServer', 'Pascal Language Server', serverOptions, clientOptions);
 	client.start();
 	client.onReady().then(function() {
 		client.onNotification(InactiveRegionNotification,setInactiveRegion);


### PR DESCRIPTION
Tracing LSP messages was broken before because of a wrong name which this fixes.