### PR TITLE
Tcpip and pipes together

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,13 +97,27 @@ The `lspprotocol.lpk` package and `pasls.lpi` are both in the
 `pascallanguageserver.lpg`project group; if you have project group support enabled,
 then you can use this to compile this package and the executable.
 
+## Run
+
+When the Pascal Language Server is started as stand-alone executable, it starts
+listening for incoming network connections on a configurable port. So that any
+client/editor can connect to it.
+
+When the application is started as a sub-proces by a client/editor, it will
+automatically detect this and use standard input to communicate with the
+client.
+
 ## Debugging the LSP server
 
-### The problem
+To debug the Pascal language Server, just run it in the debugger and let
+the editor/client connect to it usint tcp/ip.
+
+### Another way to debug
 
 VS Code and other editors that use the LSP server start the LSP server and
 send messages in JSON-RPC style to standard input, and read replies through
-standard output. This makes the LSP server process hard to debug.
+standard output. When the regular way to run the LSP server in tcp/ip mode
+is not suitable, this makes the LSP server process hard to debug.
 
 ### The solution
 To solve this, 2 extra projects have been added:

--- a/clients/pasls-vscode/package.json
+++ b/clients/pasls-vscode/package.json
@@ -77,10 +77,32 @@
 					"default": "off",
 					"description": "Traces the communication between VS Code and the language server."
 				},
+				"pascalLanguageServer.transport": {
+					"type": "string",
+					"scope": "application",
+					"default": "stdio",
+					"enum": [
+						"stdio",
+						"tcp"
+					],
+					"description": "Communication transport used between VS Code and the language server."
+				},
+				"pascalLanguageServer.tcp.host": {
+					"type": "string",
+					"scope": "application",
+					"default": "127.0.0.1",
+					"description": "Host to connect to when `pascalLanguageServer.transport` is `tcp`."
+				},
+				"pascalLanguageServer.tcp.port": {
+					"type": "number",
+					"scope": "application",
+					"default": 4002,
+					"description": "Port to connect to when `pascalLanguageServer.transport` is `tcp`."
+				},
 				"pascalLanguageServer.executable": {
 					"type": "string",
 					"default": "/usr/local/bin/pasls",
-					"description": "Path to the language server executable."
+					"description": "Path to the language server executable that is started when `pascalLanguageServer.transport` is `stdio`."
 				},
 				"pascalLanguageServer.initializationOptions.program": {
 					"type": "string",
@@ -221,6 +243,7 @@
 		"build": "vsce package"
 	},
 	"dependencies": {
+		"vsce": "^2.15.0",
 		"vscode-languageclient": "^6.1.3"
 	},
 	"devDependencies": {

--- a/clients/pasls-vscode/src/extension.ts
+++ b/clients/pasls-vscode/src/extension.ts
@@ -31,7 +31,9 @@ import {
 	ServerOptions,
 	NotificationType
 } from 'vscode-languageclient';
+import { StreamMessageReader, StreamMessageWriter } from 'vscode-languageserver-protocol';
 import * as fs from 'fs';
+import * as net from 'net';
 import { 
 	InputRegion ,
 	DecorationRangesPair,
@@ -59,6 +61,7 @@ const InactiveRegionNotification: NotificationType<InactiveRegionParams> = new N
 let client: LanguageClient;
 let completecmd: Command;
 let inactiveRegionsDecorations = new Map<string, DecorationRangesPair>();
+let tcpSocket: net.Socket | undefined;
     
 function invokeFormat(document: TextDocument, range: Range) {
 	let activeEditor = window.activeTextEditor;
@@ -236,17 +239,70 @@ export function activate(context: ExtensionContext) {
 	});
 
 
-	let run: Executable = {
-		command: executable,
-		options: {
-			env: userEnvironmentVariables
-		}
-	};
-	let debug: Executable = run;
-	let serverOptions: ServerOptions = {
-		run: run,
-		debug: debug
-	};
+	let transport: string = workspace.getConfiguration('pascalLanguageServer').get('transport') || 'stdio';
+	transport = transport.toLowerCase();
+	let tcpHost: string = workspace.getConfiguration('pascalLanguageServer').get('tcp.host') || '127.0.0.1';
+	let tcpPort: number = workspace.getConfiguration('pascalLanguageServer').get('tcp.port') || 4002;
+
+	let serverOptions: ServerOptions;
+
+	if (transport === 'tcp') {
+		serverOptions = () => {
+			return new Promise((resolve, reject) => {
+				let settled = false;
+
+				const startTime = Date.now();
+				const maxWaitMs = 10_000;
+				const retryDelayMs = 200;
+
+				const attemptConnect = () => {
+					if (settled) return;
+
+					let socket = net.connect({ host: tcpHost, port: tcpPort });
+					tcpSocket = socket;
+					socket.setNoDelay(true);
+
+					socket.once('connect', () => {
+						if (settled) return;
+						settled = true;
+
+						resolve({
+							detached: false,
+							reader: new StreamMessageReader(socket),
+							writer: new StreamMessageWriter(socket)
+						} as any);
+					});
+
+					socket.once('error', (err: Error) => {
+						socket.destroy();
+						tcpSocket = undefined;
+
+						if (settled) return;
+						if (Date.now() - startTime >= maxWaitMs) {
+							settled = true;
+							reject(err);
+							return;
+						}
+						setTimeout(attemptConnect, retryDelayMs);
+					});
+				};
+
+				attemptConnect();
+			});
+		};
+	} else {
+		let run: Executable = {
+			command: executable,
+			options: {
+				env: userEnvironmentVariables
+			}
+		};
+		let debug: Executable = run;
+		serverOptions = {
+			run: run,
+			debug: debug
+		};
+	}
 
 	let initializationOptions = workspace.getConfiguration('pascalLanguageServer.initializationOptions');
 
@@ -313,7 +369,16 @@ export function activate(context: ExtensionContext) {
 
 export function deactivate(): Thenable<void> | undefined {
 	if (!client) {
+		if (tcpSocket) {
+			tcpSocket.destroy();
+			tcpSocket = undefined;
+		}
 		return undefined;
 	}
-	return client.stop();
+	return client.stop().then(() => {
+		if (tcpSocket) {
+			tcpSocket.destroy();
+			tcpSocket = undefined;
+		}
+	});
 }

--- a/src/protocol/PasLS.TextLoop.pas
+++ b/src/protocol/PasLS.TextLoop.pas
@@ -519,6 +519,7 @@ var
 begin
   InStream:=nil;
   OutStream:=nil;
+  UseTcpIp:=false;
   try
     if ForceTcpip then
       UseTcpIp:=True
@@ -528,6 +529,11 @@ begin
       // received on stdin. If this is the case, use stdin, if not, use tcpip.
       InStream := THandleStream.Create(StdInputHandle);
       UseTcpIp := not AutoSenseDABProtocol(InStream, InitialBuffer);
+      if UseTcpIp then
+        begin
+        WriteLn('There was no client detected using standard input. To force using ');
+        WriteLn('standard input set the FORCESTDIN=TRUE environment variable.');
+        end;
       end;
 
     if UseTcpIp then
@@ -536,7 +542,10 @@ begin
       // the real connection can be made using a TTcpipConnectionThread thread.
       // So ListenForIncomingConnections is called in the background that will
       // create a TTcpipConnectionThread when a (new) connection is made.
+      begin
+      WriteLn('Start listening for incoming JSON/RPC connections on '+FListenIp+':'+IntToStr(FListenPort)+'.');
       TThread.ExecuteInThread(@ListenForIncomingConnections)
+      end
     else
       begin
       OutStream := THandleStream.Create(StdOutputHandle);

--- a/src/protocol/PasLS.TextLoop.pas
+++ b/src/protocol/PasLS.TextLoop.pas
@@ -303,7 +303,6 @@ var
   IncomingBytes: TBytes;
 begin
   IncomingBytes := AwaitMessage(FInStream, True, FInitialBuffer);
-  FContext.Log('Tadaa');
   // If IncomingBytes is empty, AwaitMessage discovered a disconnect
   while Length(IncomingBytes) > 0 do
     begin

--- a/src/protocol/PasLS.TextLoop.pas
+++ b/src/protocol/PasLS.TextLoop.pas
@@ -24,6 +24,15 @@ unit PasLS.TextLoop;
 interface
 
 uses
+  {$IFDEF UNIX}
+  BaseUnix,
+  termio,
+  {$ENDIF}
+  {$IFDEF Windows}
+  Windows,
+  WinSock2,
+  ssockets,
+  {$ENDIF}
   Classes, SysUtils, ssockets, LSP.Base, LSP.Messages, fpjson;
 
 Type
@@ -47,7 +56,7 @@ Type
   end;
 
 Procedure SetupTextLoop();
-Procedure RunMessageLoop(aDoCreateContext: TCreateLSPContextEvent; aTcpip: Boolean; aListenIpAddress: string; aListenPort: Integer);
+Procedure RunMessageLoop(aDoCreateContext: TCreateLSPContextEvent; aForceTcpip, aForceStdin: Boolean; aListenIpAddress: string; aListenPort: Integer);
 procedure DebugSendMessage(var aFile : Text; aContext : TLSPContext; const aMethod, aParams: String);
 
 implementation
@@ -90,13 +99,17 @@ type
     FIO: TLSPTextTransport;
     FLogStream: THandleStream;
 
+    // Wait a brief period of time to check whether valid lsp-commands are received
+    // on the stream. InitialBuffer returns the content of the
+    // stream that has already been consumed by the detection-mechanism.
+    function AutoSenseDABProtocol(const Stream: TStream; out InitialBuffer: string): Boolean;
     procedure HandleNewConnection(aSender: TObject; aData: TSocketStream);
     procedure StopExecution();
     procedure ListenForIncomingConnections();
     procedure InitializeLSPTextTransport(aOutStream, aLogStream: THandleStream);
   public
     constructor Create(aDoCreateContext: TCreateLSPContextEvent; aListenIpAddress: string; aListenPort: Integer);
-    procedure Execute(aTcpip: Boolean);
+    procedure Execute(ForceTcpip, ForceStdin: Boolean);
     property DoCreateContext: TCreateLSPContextEvent read FDoCreateContext;
   end;
 
@@ -109,14 +122,17 @@ type
     FContext: TLSPContext;
     FIO: TLSPTextTransport;
     FRunLoop: TRunLoop;
+    FInitialBuffer: string;
   protected
     // Processes all incoming LSP messages within the main thread and sends a
     // LSP-response when applicable
     procedure ProcessMessage();
     // Waits for a new incoming LSP message and returns the message as a array of bytes
-    function AwaitMessage(aInStream: THandleStream; aVerboseOutput: Boolean): TBytes;
+    function AwaitMessage(aInStream: THandleStream; aVerboseOutput: Boolean; anInitialBuffer: string = ''): TBytes;
   public
-    constructor Create(aInStream: THandleStream; aContext: TLSPContext; aIO: TLSPTextTransport; aRunLoop: TRunLoop);
+    // The contents in the initial buffer are processed before the content of the
+    // stream.
+    constructor Create(aInStream: THandleStream; aContext: TLSPContext; aIO: TLSPTextTransport; aRunLoop: TRunLoop; anInitialBuffer: string);
     destructor Destroy; override;
     // Main execution loop that runs in a background thread and waits for incoming
     // messages (blocking). Once a message is received it is signaled to be
@@ -217,7 +233,7 @@ begin
     end;
 end;
 
-function TTcpipConnectionThread.AwaitMessage(aInStream: THandleStream; aVerboseOutput: Boolean): TBytes;
+function TTcpipConnectionThread.AwaitMessage(aInStream: THandleStream; aVerboseOutput: Boolean; anInitialBuffer: string): TBytes;
 
 var
   ContentSize: Integer;
@@ -246,7 +262,7 @@ var
 begin
   Line := '';
   ContentSize:=0;
-  s := '';
+  s := anInitialBuffer;
   FContext.Log('Reading request');
   repeat
   PosCrLf := Pos(CRLF, s);
@@ -286,22 +302,25 @@ procedure TTcpipConnectionThread.Execute;
 var
   IncomingBytes: TBytes;
 begin
-  repeat
-  IncomingBytes := AwaitMessage(FInStream, True);
-  FContent := TEncoding.UTF8.GetString(IncomingBytes);
-  // Handle the message (or absence of a message) in the main thread
-  Synchronize(@ProcessMessage);
-
+  IncomingBytes := AwaitMessage(FInStream, True, FInitialBuffer);
+  FContext.Log('Tadaa');
   // If IncomingBytes is empty, AwaitMessage discovered a disconnect
-  until Length(IncomingBytes) = 0;
+  while Length(IncomingBytes) > 0 do
+    begin
+    FContent := TEncoding.UTF8.GetString(IncomingBytes);
+    // Handle the message (or absence of a message) in the main thread
+    Synchronize(@ProcessMessage);
+    IncomingBytes := AwaitMessage(FInStream, True);
+    end;
 end;
 
-constructor TTcpipConnectionThread.Create(aInStream: THandleStream; aContext: TLSPContext; aIO: TLSPTextTransport; aRunLoop: TRunLoop);
+constructor TTcpipConnectionThread.Create(aInStream: THandleStream; aContext: TLSPContext; aIO: TLSPTextTransport; aRunLoop: TRunLoop; anInitialBuffer: string);
 begin
   FInStream := aInStream;
   FContext:=aContext;
   FIO:=aIO;
   FRunLoop:=aRunLoop;
+  FInitialBuffer:=anInitialBuffer;
   inherited Create(False);
 end;
 
@@ -311,7 +330,7 @@ begin
   inherited Destroy;
 end;
 
-Procedure RunMessageLoop(aDoCreateContext: TCreateLSPContextEvent; aTcpip: Boolean; aListenIpAddress: string; aListenPort: Integer);
+Procedure RunMessageLoop(aDoCreateContext: TCreateLSPContextEvent; aForceTcpip, aForceStdIn: Boolean; aListenIpAddress: string; aListenPort: Integer);
 
 var
   RunLoop: TRunLoop;
@@ -319,7 +338,7 @@ var
 begin
   RunLoop := TRunLoop.Create(aDoCreateContext, aListenIpAddress, aListenPort);
   try
-    RunLoop.Execute(aTcpip);
+    RunLoop.Execute(aForceTcpip, aForceStdIn);
   finally
     RunLoop.Free;
   end;
@@ -382,7 +401,7 @@ begin
 
   FContext.Log('New incoming connection');
 
-  ConnThread := TTcpipConnectionThread.create(aData, FContext, FIO, Self);
+  ConnThread := TTcpipConnectionThread.create(aData, FContext, FIO, Self, '');
   ConnThread.FreeOnTerminate:=True;
 end;
 
@@ -433,15 +452,86 @@ begin
   FListenPort:=aListenPort;
 end;
 
-procedure TRunLoop.Execute(aTcpip: Boolean);
+function TRunLoop.AutoSenseDABProtocol(const Stream: TStream; out InitialBuffer: string): Boolean;
+
+  function NumBytesAvailable: DWord;
+  begin
+    {$IFDEF Unix}
+    if fpioctl((Stream as THandleStream).Handle, FIONREAD, @Result)<0 then
+      Result := 0;
+    {$ENDIF Unix}
+    {$IFDEF Windows}
+    if Stream is TSocketStream then
+      begin
+      if ioctlsocket(TSocketStream(Stream).Handle, FIONREAD, @Result)<0 then
+        Result := 0;
+      end
+    else if Stream is THandleStream then
+      begin
+      if not PeekNamedPipe(THandleStream(Stream).Handle, nil, 0, nil, @Result, nil) then
+        Result := 0;
+      end
+    else
+      Result := 0;
+    {$ENDIF}
+  end;
+
+var
+  Buf: string;
+  i,l: LongInt;
+begin
+  Result := False;
+  InitialBuffer := '';
+
+  // TInputPipeStream could not be used, because it closes the handle when it
+  // gets destroyed.
+
+  // Wait at the most 20*10 milliseconds for enough input on the console to detect
+  // the DAB-protocol.
+  for i := 0 to 20 do
+    begin
+    if NumBytesAvailable > 15 then
+      begin
+      // There are at least 16 bytes in the buffer. Check if these bytes look
+      // like a DAB-header.
+      Buf:='';
+      SetLength(Buf,16);
+      l := Stream.Read(Buf[1], 16);
+      SetLength(Buf, l);
+      Result := Buf = 'Content-Length: ';
+
+      // Fill the initial-buffer with the data that we 'peeked' from stdin
+      // I could not find a reliable, cross-platform way to perform a 'real'
+      // peek.
+      InitialBuffer := Buf;
+      break;
+      end;
+    sleep(10);
+    end;
+end;
+
+
+procedure TRunLoop.Execute(ForceTcpip, ForceStdin: Boolean);
 var
   InStream, OutStream: THandleStream;
   ConnThread: TTcpipConnectionThread;
+  InitialBuffer: string;
+  UseTcpIp: Boolean;
 begin
   InStream:=nil;
   OutStream:=nil;
   try
-    if aTcpip then
+    if ForceTcpip then
+      UseTcpIp:=True
+    else if not ForceStdin then
+      begin
+      // Wait for a small period of time to check whether valid commands are
+      // received on stdin. If this is the case, use stdin, if not, use tcpip.
+      InStream := THandleStream.Create(StdInputHandle);
+      UseTcpIp := not AutoSenseDABProtocol(InStream, InitialBuffer);
+      end;
+
+    if UseTcpIp then
       // The biggest difference with a tcpip-server (listening) socket is that multiple
       // connections can come in. So we have to wait for a connection before
       // the real connection can be made using a TTcpipConnectionThread thread.
@@ -450,14 +540,17 @@ begin
       TThread.ExecuteInThread(@ListenForIncomingConnections)
     else
       begin
-      InStream := THandleStream.Create(StdInputHandle);
       OutStream := THandleStream.Create(StdOutputHandle);
       FLogStream := THandleStream.Create(StdErrorHandle);
 
       InitializeLSPTextTransport(OutStream, FLogStream);
 
-      ConnThread := TTcpipConnectionThread.Create(InStream, FContext, FIO, Self);
+      ConnThread := TTcpipConnectionThread.Create(InStream, FContext, FIO, Self, InitialBuffer);
       ConnThread.FreeOnTerminate:=True;
+      // By assigning nil to InStream, it is not freed.
+      // This is done because stdin cannot be closed, or else rtl will raise an
+      // exception when the application terminates.
+      InStream := nil;
       end;
 
     repeat

--- a/src/standard/PasLS.LSConfig.pas
+++ b/src/standard/PasLS.LSConfig.pas
@@ -33,6 +33,10 @@ Const
   DefaultFPCDir = '';
   DefaultTargetOS = {$i %FPCTARGETOS%};
   DefaultTargetCPU = {$i %FPCTARGETCPU%};
+  DefaultListenPort = 4002;
+  DefaultListenIP = '0.0.0.0';
+  DefaultForceStdin = false;
+  DefaultForceTcpip = false;
 
 Type
   { TLSPServerConfig }
@@ -40,8 +44,12 @@ Type
   TLSPServerConfig = Class(TObject)
   private
     FCompiler: string;
+    FForceStdin: Boolean;
+    FForceTcpip: Boolean;
     FFPCDir: string;
     FLazarusDir: string;
+    FListenIp: string;
+    FListenPort: word;
     FLogFile: String;
     FTargetCPU: string;
     FTargetOS: string;
@@ -60,6 +68,10 @@ Type
     property LazarusDir : string read FLazarusDir write FLazarusDir;
     property TargetOS : string read FTargetOS write FTargetOS;
     property TargetCPU : string read FTargetCPU write FTargetCPU;
+    property ListenIp : string read FListenIp write FListenIp;
+    property ListenPort : word read FListenPort write FListenPort;
+    property ForceStdin : Boolean read FForceStdin write FForceStdin;
+    property ForceTcpip : Boolean read FForceTcpip write FForceTcpip;
   end;
 
 
@@ -75,6 +87,10 @@ Const
   KeyLazarusDir = 'LazarusDir';
   KeyTargetCPU = 'TargetCPU';
   KeyTargetOS = 'TargetOS';
+  KeyListenIp = 'ListenIp';
+  KeyListenPort = 'ListenPort';
+  KeyForceStdin = 'ForceStdin';
+  KeyForceTcpip = 'ForceTcpip';
 
 { TLSPServerConfig }
 
@@ -91,6 +107,10 @@ begin
   LazarusDir:=DefaultLazarusDir;
   TargetCPU:=DefaultTargetCPU;
   TargetOS:=DefaultTargetOS;
+  ListenPort:=DefaultListenPort;
+  ListenIP:=DefaultListenIP;
+  ForceStdin:=DefaultForceStdin;
+  ForceTcpip:=DefaultForceTcpip;
 end;
 
 class function TLSPServerConfig.DefaultConfigFile: String;
@@ -135,6 +155,10 @@ begin
   With aIni do
     begin
     FLogFile:=ReadString(SServer,KeyLogFile,LogFile);
+    ListenIp:=ReadString(SServer,KeyListenIp,ListenIp);
+    ListenPort:=ReadInteger(SServer,KeyListenPort,ListenPort);
+    ForceTcpip:=ReadBool(SServer,KeyForceTcpip,ForceTcpip);
+    ForceStdin:=ReadBool(SServer,KeyForceStdin,ForceStdin);
     Compiler:=ReadString(SCodeTools,KeyCompiler,Compiler);
     FPCDir:=ReadString(SCodetools,KeyFPCDir,FPCDir);
     LazarusDir:=ReadString(SCodetools,KeyLazarusDir,LazarusDir);
@@ -148,6 +172,10 @@ begin
   With aIni do
     begin
     WriteString(SServer,KeyLogFile,LogFile);
+    WriteString(SServer,KeyListenIp,ListenIp);
+    WriteInteger(SServer,KeyListenPort,ListenPort);
+    WriteBool(SServer,KeyForceStdin,ForceStdin);
+    WriteBool(SServer,KeyForceTcpip,ForceTcpip);
     WriteString(SCodeTools,KeyCompiler,Compiler);
     WriteString(SCodetools,KeyFPCDir,FPCDir);
     WriteString(SCodetools,KeyLazarusDir,LazarusDir);

--- a/src/standard/pasls.lpr
+++ b/src/standard/pasls.lpr
@@ -29,6 +29,8 @@ uses
   { RTL }
   {$ifdef unix}cthreads,{$endif}
   SysUtils, Classes, FPJson, JSONParser, JSONScanner, TypInfo,
+  { Lazarus }
+  LazUTF8,
   { Protocol }
   PasLS.AllCommands, PasLS.Settings, PasLS.Commands,
   LSP.Base, LSP.Basic, LSP.Capabilities, LSP.Options,
@@ -306,6 +308,23 @@ begin
   Result := aContext;
 end;
 
+procedure ApplyEnvironmentVariables;
+const
+  sListenIpEnv = 'LISTENIP';
+  sListenPortEnv = 'LISTENPORT';
+  sForceStdin = 'FORCESTDIN';
+  sForceTcpip = 'FORCETCPIP';
+begin
+  if GetEnvironmentVariableUTF8(sListenIpEnv)<>'' then
+    aCfg.ListenIp:=GetEnvironmentVariableUTF8(sListenIpEnv);
+  if GetEnvironmentVariableUTF8(sListenPortEnv)<>'' then
+    aCfg.ListenPort:=StrToInt(GetEnvironmentVariableUTF8(sListenPortEnv));
+  if GetEnvironmentVariableUTF8(sForceStdin)<>'' then
+    aCfg.ForceStdin:=StrToBoolDef(GetEnvironmentVariableUTF8(sForceStdin), False);
+  if GetEnvironmentVariableUTF8(sForceTcpip)<>'' then
+    aCfg.ForceTcpip:=StrToBoolDef(GetEnvironmentVariableUTF8(sForceTcpip), False);
+end;
+
 var
   ForceTcpip, ForceStdIn: Boolean;
   ListenIp: String;
@@ -342,13 +361,20 @@ begin
       TLSPContext.LogFile := aCfg.LogFile;
     ConfigEnvironment(aCfg);
 
+    ApplyEnvironmentVariables();
+
     SetupTextLoop();
 
-    // ToDo: make these configurable
-    ForceTcpip := false;
-    ForceStdIn := false;
-    ListenIp := '0.0.0.0';
-    Port := 4002;
+    if aCfg.ForceTcpip and aCfg.ForceStdin then
+      begin
+      WriteLn('It is not possible to use tcp/ip and stdin simultaneously. Stdin is used.');
+      aCfg.ForceTcpip:=False;
+      end;
+
+    ForceTcpip := aCfg.ForceTcpip;
+    ForceStdIn := aCfg.ForceStdin;
+    ListenIp := aCfg.ListenIp;
+    Port := aCfg.ListenPort;
 
     RunMessageLoop(@DoInitializeContext, ForceTcpip, ForceStdIn, ListenIp, Port);
    Finally

--- a/src/standard/pasls.lpr
+++ b/src/standard/pasls.lpr
@@ -27,7 +27,8 @@ uses
   Windows,
   {$ENDIF}
   { RTL }
-  SysUtils, Classes, FPJson, JSONParser, JSONScanner, TypInfo,
+  {$ifdef unix}cthreads,{$endif}
+  SysUtils, Classes, FPJson, JSONParser, JSONScanner, TyoInfo,
   { Protocol }
   PasLS.AllCommands, PasLS.Settings, PasLS.Commands,
   LSP.Base, LSP.Basic, LSP.Capabilities, LSP.Options,
@@ -294,6 +295,21 @@ begin
   Log('Transport log: '+Msg);
 end;
 
+function DoInitializeContext(OutStream, LogStream: THandleStream): TLSPContext;
+begin
+  aTransport:=TLSPTextTransport.Create(OutStream, LogStream);
+  aDisp:=TLSPLocalDispatcher.Create(aTransport,True);
+  aContext:=TLSPLogContext.Create(aTransport,aDisp,True);
+  aTransport.OnLog := @aContext.DoTransportLog;
+  if not ExecuteCommandLineMessages(aContext) then
+    exit(nil);
+  Result := aContext;
+end;
+
+var
+  Tcpip: Boolean;
+  ListenIp: String;
+  Port: Integer;
 
 begin
   // Show help for the server
@@ -325,16 +341,18 @@ begin
     if aCfg.LogFile<>'' then
       TLSPContext.LogFile := aCfg.LogFile;
     ConfigEnvironment(aCfg);
-    SetupTextLoop(Input,Output,StdErr);
-    aTransport:=TLSPTextTransport.Create(@Output,@StdErr);
-    aDisp:=TLSPLocalDispatcher.Create(aTransport,True);
-    aContext:=TLSPLogContext.Create(aTransport,aDisp,True);
-    aTransport.OnLog := @aContext.DoTransportLog;
-    if not ExecuteCommandLineMessages(aContext) then
-      exit;
-    RunMessageLoop(Input,Output,StdErr,aContext);
+
+    SetupTextLoop();
+
+    // ToDo: make these configurable
+    Tcpip := False;
+    ListenIp := '0.0.0.0';
+    Port := 4002;
+
+    RunMessageLoop(@DoInitializeContext, Tcpip, ListenIp, Port);
    Finally
      aContext.Free;
+     aTransport.Free;
      aCfg.Free;
    end;
 end.

--- a/src/standard/pasls.lpr
+++ b/src/standard/pasls.lpr
@@ -28,7 +28,7 @@ uses
   {$ENDIF}
   { RTL }
   {$ifdef unix}cthreads,{$endif}
-  SysUtils, Classes, FPJson, JSONParser, JSONScanner, TyoInfo,
+  SysUtils, Classes, FPJson, JSONParser, JSONScanner, TypInfo,
   { Protocol }
   PasLS.AllCommands, PasLS.Settings, PasLS.Commands,
   LSP.Base, LSP.Basic, LSP.Capabilities, LSP.Options,
@@ -307,7 +307,7 @@ begin
 end;
 
 var
-  Tcpip: Boolean;
+  ForceTcpip, ForceStdIn: Boolean;
   ListenIp: String;
   Port: Integer;
 
@@ -345,11 +345,12 @@ begin
     SetupTextLoop();
 
     // ToDo: make these configurable
-    Tcpip := False;
+    ForceTcpip := false;
+    ForceStdIn := false;
     ListenIp := '0.0.0.0';
     Port := 4002;
 
-    RunMessageLoop(@DoInitializeContext, Tcpip, ListenIp, Port);
+    RunMessageLoop(@DoInitializeContext, ForceTcpip, ForceStdIn, ListenIp, Port);
    Finally
      aContext.Free;
      aTransport.Free;


### PR DESCRIPTION
This change adapts the LSP so that it can run in tcp/ip _and_ stdio mode. This makes it much easier to debug the LSP.

The vscode plugin is adapted so that it can run both modes. 

By default, when the LSP is started, it waits a few milliseconds for input on stdin that looks like a LSP-command. When this is received, it switches to stdio mode. When not, is starts listening on a tcp/ip port.

It is possible to enforce stdio/tcpip in the command line, port and host are also configurable.

