### PR TITLE
Update properties type deemed optional in spec to TOptional...

### DIFF
--- a/src/protocol/LSP.Basic.pas
+++ b/src/protocol/LSP.Basic.pas
@@ -376,8 +376,8 @@ type
   private
     fRange: TRange;
     fSeverity: TDiagnosticSeverity;
-    fCode: integer;
-    fSource: string;
+    fCode: TOptionalInteger;
+    fSource: TOptionalString;
     fMessage: string;
     procedure SetRange(AValue: TRange);
   Public
@@ -391,10 +391,10 @@ type
     // client to interpret diagnostics as error, warning, info or hint.
     property severity: TDiagnosticSeverity read fSeverity write fSeverity;
     // The diagnostic's code, which might appear in the user interface.
-    property code: integer read fCode write fCode;
+    property code: TOptionalInteger read fCode write fCode;
     // A human-readable string describing the source of this
     // diagnostic, e.g. 'typescript' or 'super lint'.
-    property source: string read fSource write fSource;
+    property source: TOptionalString read fSource write fSource;
     // The diagnostic's message.
     property message: string read fMessage write fMessage;
 
@@ -1107,7 +1107,8 @@ begin
     Severity:=Src.severity;
     Code:=Src.Code;
     self.Source:=Src.Source;
-    Message:=Src.Source;
+    if Src.source.HasValue then
+      Message:=Src.Source.Value;
     end
   else
     inherited Assign(Source);
@@ -1115,4 +1116,3 @@ end;
 
 
 end.
-  

--- a/src/protocol/LSP.Completion.pas
+++ b/src/protocol/LSP.Completion.pas
@@ -152,12 +152,12 @@ type
     fLabel: string;
     fKind: TCompletionItemKind;
     fTags: TCompletionItemTags;
-    fDetail: string;
+    fDetail: TOptionalString;
     fDocumentation: TMarkupContent;
     fPreselect: Boolean;
-    fSortText: string;
-    fFilterText: string;
-    fInsertText: string;
+    fSortText: TOptionalString;
+    fFilterText: TOptionalString;
+    fInsertText: TOptionalString;
     fInsertTextFormat: TInsertTextFormat;
     fTextEdit: TTextEdit;
     fAdditionalTextEdits: TTextEdits;
@@ -184,7 +184,7 @@ type
     property tags: TCompletionItemTags read fTags write fTags;
     // A human-readable string with additional information about this
     // item, like type or symbol information.
-    property detail: string read fDetail write fDetail;
+    property detail: TOptionalString read fDetail write fDetail;
     // A human-readable string that represents a doc-comment.
     property documentation: TMarkupContent read fDocumentation write SetDocumentation;
     // Select this item when showing.
@@ -195,10 +195,10 @@ type
     property preselect: Boolean read fPreselect write fPreselect;
     // A string that should be used when comparing this item
     // with other items. When `falsy` the label is used.
-    property sortText: string read fSortText write fSortText;
+    property sortText: TOptionalString read fSortText write fSortText;
     // A string that should be used when filtering a set of
     // completion items. When `falsy` the label is used.
-    property filterText: string read fFilterText write fFilterText;
+    property filterText: TOptionalString read fFilterText write fFilterText;
     // A string that should be inserted into a document when selecting
     // this completion. When `falsy` the label is used.
     //
@@ -209,7 +209,7 @@ type
     // `insertText` of `console` is provided it will only insert
     // `sole`. Therefore it is recommended to use `textEdit` instead
     // since it avoids additional client side interpretation.
-    property insertText: string read fInsertText write fInsertText;
+    property insertText: TOptionalString read fInsertText write fInsertText;
     // The format of the insert text. The format applies to both the
     // `insertText` property and the `newText` property of a provided
     // `textEdit`. If omitted defaults to

--- a/src/protocol/LSP.DocumentSymbol.pas
+++ b/src/protocol/LSP.DocumentSymbol.pas
@@ -74,7 +74,7 @@ type
   TDocumentSymbol = class(TCollectionItem)
   private
     fName: string;
-    fDetail: string;
+    fDetail: TOptionalString;
     fKind: TSymbolKind;
     fDeprecated: boolean;
     fRange: TRange;
@@ -92,7 +92,7 @@ type
     // an empty string or a string only consisting of white spaces.
     property name: string read fName write fName;
     // More detail for this symbol, e.g the signature of a function.
-    property detail: string read fDetail write fDetail;
+    property detail: TOptionalString read fDetail write fDetail;
     // The kind of this symbol.
     property kind: TSymbolKind read fKind write fKind;
     // Indicates if this symbol is deprecated.

--- a/src/protocol/LSP.General.pas
+++ b/src/protocol/LSP.General.pas
@@ -59,14 +59,14 @@ type
   TClientInfo = class(TLSPStreamable)
   private
     fName: string;
-    fVersion: string;
+    fVersion: TOptionalString;
   Public
     Procedure Assign(aSource : TPersistent); override;
   published
     // The name of the client as defined by the client.
     property name: string read fName write fName;
     // The client's version as defined by the client.
-    property version: string read fVersion write fVersion;
+    property version: TOptionalString read fVersion write fVersion;
   end;
 
 

--- a/src/protocol/LSP.InlayHint.pas
+++ b/src/protocol/LSP.InlayHint.pas
@@ -53,7 +53,7 @@ type
     fLabel: String; // string | InlayHintLabelPart[] (not supported now)
     fKind: TOptionalInlayHintKind;
     fTextEdits: TTextEdits;
-    fTooltip: String;
+    fTooltip: TOptionalString;
   public
     Constructor Create(ACollection: TCollection); override;
   published
@@ -81,7 +81,7 @@ type
     //
     // Depending on the client capability `inlayHint.resolveSupport` clients
     // might resolve this property late using the resolve request.
-    property tooltip: String read fTooltip write fTooltip;
+    property tooltip: TOptionalString read fTooltip write fTooltip;
   public
     destructor Destroy; override;
   end;

--- a/src/serverprotocol/PasLS.General.pas
+++ b/src/serverprotocol/PasLS.General.pas
@@ -248,11 +248,17 @@ end;
 procedure TInitialize.ShowConfigStatus(Params: TInitializeParams; CodeToolsOptions: TCodeToolsOptions);
 var
   ExcludeList, Option: String;
+  clientInfoVersion: String;
   I: Integer;
   FPCOptions: TStringArray;
 begin
+  if Params.clientInfo.version.HasValue then
+    clientInfoVersion := ' ' + Params.clientInfo.version.Value
+  else
+    clientInfoVersion := '';
+
   DoLog(kStatusPrefix+'Server: ' + {$INCLUDE %DATE%});
-  DoLog(kStatusPrefix+'Client: ' + Params.clientInfo.name + ' ' + Params.clientInfo.version);
+  DoLog(kStatusPrefix+'Client: ' + Params.clientInfo.name + clientInfoVersion);
 
   DoLog(kStatusPrefix+'FPCPath: ' + CodeToolsOptions.FPCPath);
   DoLog(kStatusPrefix+'FPCSrcDir: ' + CodeToolsOptions.FPCSrcDir);

--- a/src/serverprotocol/lspserver.pas
+++ b/src/serverprotocol/lspserver.pas
@@ -18,7 +18,6 @@ uses
   PasLS.DocumentSymbol, PasLS.Commands, PasLS.Formatter, PasLS.ExecuteCommand, 
   PasLS.CodeUtils, PasLS.InvertAssign, PasLS.LazConfig, PasLS.Parser, 
   PasLS.Symbols, PasLS.CheckInactiveRegions, PasLS.InactiveRegions, 
-  PasLS.Command.RemoveUnusedUnits, PasLS.RemoveUnusedUnits,
   PasLS.Rename, LazarusPackageIntf;
 
 implementation


### PR DESCRIPTION
Some LSP client (Zed) not behaving correctly if theese properties exists even if it has 'falsy' value. Updating to TOptional so they can be set nil and not incorporated during JSON serialization.

Affected properties:

TDiagnostic.fCode: TOptionalInteger;
TDiagnostic.Source: TOptionalString;
TCompletionItem.fDetail: TOptionalString;
TCompletionItem.fSortText: TOptionalString;
TCompletionItem.fFilterText: TOptionalString;
TCompletionItem.fInsertText: TOptionalString;
TDocumentSymbol.fDetail: TOptionalString;
TClientInfo.fVersion: TOptionalString;
TInlayHint.fTooltip: TOptionalString;